### PR TITLE
feat: enable /schedule by adding AGENT_TRIGGERS_REMOTE to default features

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -8,10 +8,15 @@ const outdir = "dist";
 const { rmSync } = await import("fs");
 rmSync(outdir, { recursive: true, force: true });
 
+// Default features that match the official CLI build.
+// Additional features can be enabled via FEATURE_<NAME>=1 env vars.
+const DEFAULT_BUILD_FEATURES = ["AGENT_TRIGGERS_REMOTE"];
+
 // Collect FEATURE_* env vars → Bun.build features
-const features = Object.keys(process.env)
+const envFeatures = Object.keys(process.env)
     .filter(k => k.startsWith("FEATURE_"))
     .map(k => k.replace("FEATURE_", ""));
+const features = [...new Set([...DEFAULT_BUILD_FEATURES, ...envFeatures])];
 
 // Step 2: Bundle with splitting
 const result = await Bun.build({

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -15,7 +15,7 @@ const defineArgs = Object.entries(defines).flatMap(([k, v]) => [
 
 // Bun --feature flags: enable feature() gates at runtime.
 // Default features enabled in dev mode.
-const DEFAULT_FEATURES = ["BUDDY", "TRANSCRIPT_CLASSIFIER", "BRIDGE_MODE"];
+const DEFAULT_FEATURES = ["BUDDY", "TRANSCRIPT_CLASSIFIER", "BRIDGE_MODE", "AGENT_TRIGGERS_REMOTE"];
 
 // Any env var matching FEATURE_<NAME>=1 will also enable that feature.
 // e.g. FEATURE_PROACTIVE=1 bun run dev


### PR DESCRIPTION
## Summary

- `scripts/dev.ts`: `DEFAULT_FEATURES` 加入 `"AGENT_TRIGGERS_REMOTE"`
- `build.ts`: 新增 `DEFAULT_BUILD_FEATURES = ["AGENT_TRIGGERS_REMOTE"]`，与 env 合并

## Why

`/schedule` skill 和 `RemoteTriggerTool` 源码已在 `src/` 中，但 `feature('AGENT_TRIGGERS_REMOTE')` 构建时默认 `false`，Bun DCE 把整条链路裁掉了。只需开启编译开关即可恢复。

## Test plan

- [ ] `bun run dev` → 输入 `/schedule` 能看到交互式工作流
- [ ] `bun run build` → `dist/` 中包含 `"scheduled remote agents"` 字符串
- [ ] `/loop` 和 CronCreate/Delete/List 不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build system feature flag handling with explicit configuration and automatic deduplication
  * Enhanced development environment with expanded runtime feature support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->