### PR TITLE
test: add coverage for formatRelativeTimeAgo and formatLogMetadata

### DIFF
--- a/src/utils/__tests__/format.test.ts
+++ b/src/utils/__tests__/format.test.ts
@@ -6,6 +6,8 @@ import {
   formatNumber,
   formatTokens,
   formatRelativeTime,
+  formatRelativeTimeAgo,
+  formatLogMetadata,
 } from "../format";
 
 describe("formatFileSize", () => {
@@ -151,5 +153,146 @@ describe("formatRelativeTime", () => {
   test("formats weeks ago", () => {
     const date = new Date("2026-01-01T12:00:00Z");
     expect(formatRelativeTime(date, { now })).toBe("2w ago");
+  });
+});
+
+describe("formatRelativeTimeAgo", () => {
+  const now = new Date("2026-01-15T12:00:00Z");
+
+  test("formats past date with 'ago' suffix", () => {
+    const date = new Date("2026-01-15T11:59:30Z");
+    const result = formatRelativeTimeAgo(date, { now });
+    expect(result).toBe("30s ago");
+  });
+
+  test("formats future date without 'ago' suffix", () => {
+    const date = new Date("2026-01-15T13:00:00Z");
+    const result = formatRelativeTimeAgo(date, { now });
+    expect(result).toBe("in 1h");
+  });
+
+  test("formats minutes ago", () => {
+    const date = new Date("2026-01-15T11:55:00Z");
+    const result = formatRelativeTimeAgo(date, { now });
+    expect(result).toBe("5m ago");
+  });
+
+  test("formats hours ago", () => {
+    const date = new Date("2026-01-15T09:00:00Z");
+    const result = formatRelativeTimeAgo(date, { now });
+    expect(result).toBe("3h ago");
+  });
+
+  test("formats days ago", () => {
+    const date = new Date("2026-01-13T12:00:00Z");
+    const result = formatRelativeTimeAgo(date, { now });
+    expect(result).toBe("2d ago");
+  });
+
+  test("handles date equal to now as past", () => {
+    // date === now, treated as past (not future)
+    const result = formatRelativeTimeAgo(now, { now });
+    expect(result).toBe("0s ago");
+  });
+
+  test("uses numeric always for past dates", () => {
+    // Should always use numeric format for past dates
+    const date = new Date("2026-01-15T11:59:00Z");
+    const result = formatRelativeTimeAgo(date, { now });
+    expect(result).toContain("ago");
+  });
+
+  test("future date does not contain 'ago'", () => {
+    const date = new Date("2026-01-15T14:00:00Z");
+    const result = formatRelativeTimeAgo(date, { now });
+    expect(result).not.toContain("ago");
+  });
+});
+
+describe("formatLogMetadata", () => {
+  // Use a date very recently in the past so it always shows "Xs ago" or similar
+  const modified = new Date(Date.now() - 5 * 60 * 1000); // 5 minutes ago
+
+  test("includes relative time and message count", () => {
+    const result = formatLogMetadata({
+      modified,
+      messageCount: 10,
+    });
+    expect(result).toContain("ago");
+    expect(result).toContain("10 messages");
+  });
+
+  test("uses fileSize instead of messageCount when provided", () => {
+    const result = formatLogMetadata({
+      modified,
+      messageCount: 5,
+      fileSize: 1536,
+    });
+    expect(result).toContain("1.5KB");
+    expect(result).not.toContain("messages");
+  });
+
+  test("includes gitBranch when provided", () => {
+    const result = formatLogMetadata({
+      modified,
+      messageCount: 3,
+      gitBranch: "main",
+    });
+    expect(result).toContain("main");
+  });
+
+  test("omits gitBranch when not provided", () => {
+    const result = formatLogMetadata({
+      modified,
+      messageCount: 3,
+    });
+    // Should not have a dangling separator from missing branch
+    expect(result).not.toMatch(/^ · | · $/);
+  });
+
+  test("includes tag when provided", () => {
+    const result = formatLogMetadata({
+      modified,
+      messageCount: 3,
+      tag: "my-tag",
+    });
+    expect(result).toContain("#my-tag");
+  });
+
+  test("includes agentSetting when provided", () => {
+    const result = formatLogMetadata({
+      modified,
+      messageCount: 3,
+      agentSetting: "custom-agent",
+    });
+    expect(result).toContain("@custom-agent");
+  });
+
+  test("includes prNumber when provided", () => {
+    const result = formatLogMetadata({
+      modified,
+      messageCount: 3,
+      prNumber: 42,
+    });
+    expect(result).toContain("#42");
+  });
+
+  test("includes prRepository with prNumber when both provided", () => {
+    const result = formatLogMetadata({
+      modified,
+      messageCount: 3,
+      prNumber: 99,
+      prRepository: "owner/repo",
+    });
+    expect(result).toContain("owner/repo#99");
+  });
+
+  test("parts are joined with ' · ' separator", () => {
+    const result = formatLogMetadata({
+      modified,
+      messageCount: 5,
+      gitBranch: "feat/x",
+    });
+    expect(result).toContain(" · ");
   });
 });


### PR DESCRIPTION
## Summary

- `formatRelativeTimeAgo` and `formatLogMetadata` are exported from `src/utils/format.ts` and used throughout the codebase (in `HistorySearchDialog`, `LogSelector`, `SessionPreview`, `Settings/Usage`, etc.) but had no unit tests
- Added 8 tests for `formatRelativeTimeAgo` covering: past dates, future dates, equal-to-now edge case, minutes/hours/days ago, and the invariant that future dates never contain "ago"
- Added 9 tests for `formatLogMetadata` covering: message count, fileSize override, all optional fields (`gitBranch`, `tag`, `agentSetting`, `prNumber`, `prRepository`), and the `' · '` separator format

## Test plan

- [ ] Run `bun test src/utils/__tests__/format.test.ts` — all existing tests continue to pass, new tests pass
- [ ] Verify the new tests cover the key behaviors of both functions without relying on wall-clock time (the `formatRelativeTimeAgo` tests pass a fixed `now` option; `formatLogMetadata` tests use pattern matching for time-relative assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for relative time formatting, validating past/future timestamp handling with appropriate suffixes and formatting conventions
  * Expanded tests for metadata display, ensuring proper handling of file sizes, message counts, optional metadata fields, and composite string assembly with appropriate separators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->