### PR TITLE
test: add coverage for toRelativePath and getDirectoryForPath

### DIFF
--- a/src/utils/__tests__/path.test.ts
+++ b/src/utils/__tests__/path.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { resolve } from "path";
 import {
   containsPathTraversal,
   expandPath,
   normalizePathForConfigKey,
+  toRelativePath,
+  getDirectoryForPath,
 } from "../path";
 
 // ─── containsPathTraversal ──────────────────────────────────────────────
@@ -127,5 +130,70 @@ describe("normalizePathForConfigKey", () => {
   test("normalizes redundant separators foo//bar", () => {
     const result = normalizePathForConfigKey("foo//bar");
     expect(result).toBe("foo/bar");
+  });
+});
+
+// ─── toRelativePath ─────────────────────────────────────────────────────
+
+describe("toRelativePath", () => {
+  test("returns relative path for a child of cwd", () => {
+    // Build a path that is inside the current working directory.
+    // resolve() returns an absolute path, and toRelativePath should give
+    // back just the final segment (or relative form without ..).
+    const abs = resolve(process.cwd(), "package.json");
+    const result = toRelativePath(abs);
+    expect(result).toBe("package.json");
+    expect(result).not.toContain("..");
+  });
+
+  test("returns absolute path when target is outside cwd", () => {
+    // A well-known absolute path that is always outside any typical cwd
+    // (any absolute path that doesn't start with process.cwd() will work)
+    const cwd = process.cwd();
+    // Build a path guaranteed to be outside cwd by going to the root's parent
+    // of cwd, then a sibling directory with an unlikely name
+    const outsidePath = resolve(cwd, "../../__unlikely_dir_xyz__");
+    const result = toRelativePath(outsidePath);
+    // relative(cwd, outsidePath) will start with '../..' so function returns absolute
+    expect(result).toBe(outsidePath);
+  });
+
+  test("returns empty string for cwd itself", () => {
+    const cwd = process.cwd();
+    const result = toRelativePath(cwd);
+    // relative(cwd, cwd) === '' which does not start with '..'
+    expect(result).toBe("");
+  });
+
+  test("returns a string for any absolute path", () => {
+    const abs = resolve(process.cwd(), "src");
+    const result = toRelativePath(abs);
+    expect(typeof result).toBe("string");
+  });
+});
+
+// ─── getDirectoryForPath ─────────────────────────────────────────────────
+
+describe("getDirectoryForPath", () => {
+  test("returns the path itself when given an existing directory", () => {
+    // The src directory is guaranteed to exist in this repo
+    const dir = resolve(process.cwd(), "src");
+    const result = getDirectoryForPath(dir);
+    expect(result).toBe(dir);
+  });
+
+  test("returns parent directory for a known file", () => {
+    // package.json is at the repo root
+    const file = resolve(process.cwd(), "package.json");
+    const expectedParent = process.cwd();
+    const result = getDirectoryForPath(file);
+    expect(result).toBe(expectedParent);
+  });
+
+  test("returns parent directory for a non-existent path", () => {
+    const nonExistent = resolve(process.cwd(), "does-not-exist-xyz123.ts");
+    const expectedParent = process.cwd();
+    const result = getDirectoryForPath(nonExistent);
+    expect(result).toBe(expectedParent);
   });
 });


### PR DESCRIPTION
## Summary

- `toRelativePath` and `getDirectoryForPath` are exported from `src/utils/path.ts` and used throughout the codebase but had no unit tests
- Added 4 tests for `toRelativePath`: returns a relative path for children of CWD, keeps the absolute path when the target is outside CWD (relative would start with `..`), returns `""` for CWD itself, and type-safety invariant
- Added 3 tests for `getDirectoryForPath`: returns the path itself for an existing directory, returns the parent directory for a known file, and returns the parent directory for a non-existent path

## Test plan

- [ ] Run `bun test src/utils/__tests__/path.test.ts` — all existing tests continue to pass, new tests pass
- [ ] Tests use `process.cwd()` and `resolve()` so they work against the actual repo structure without any mocking (the `src/` directory and `package.json` are guaranteed to exist at the repo root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for path utility functions with new test cases verifying behavior in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->