### PR TITLE
fix: simplify postinstall script to avoid error on fresh install

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test": "bun test",
     "check:unused": "knip-bun",
     "health": "bun run scripts/health-check.ts",
-    "postinstall": "node dist/download-ripgrep.js || bun run scripts/download-ripgrep.ts || true",
+    "postinstall": "bun run scripts/download-ripgrep.ts || true",
     "docs:dev": "npx mintlify dev"
   },
   "dependencies": {},


### PR DESCRIPTION
## Summary

- Simplified `postinstall` script to directly use `bun run scripts/download-ripgrep.ts`
- Removed the fallback chain `node dist/download-ripgrep.js || bun run scripts/download-ripgrep.ts || true`

## Problem

On fresh `bun install`, the previous postinstall script would first try to run `node dist/download-ripgrep.js`, which fails because `dist/` doesn't exist yet. While the fallback to `bun run scripts/download-ripgrep.ts` worked correctly, it produced confusing error output like:

```
Error: Cannot find module '/path/to/dist/download-ripgrep.js'
```

## Solution

Since Bun can run `.ts` files directly and `scripts/download-ripgrep.ts` already handles both dev mode (when `src/` exists) and published mode (when running from `dist/`), we can simplify to just use the TypeScript script directly.

## Test plan

- [x] Run `bun install` on a fresh clone - no more spurious error output
- [x] Ripgrep binary still downloads correctly when needed
- [x] Idempotent behavior preserved (skips if binary exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the `postinstall` script to streamline the dependency installation process while maintaining fallback reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->