### PR TITLE
fix: 修复代码不能在终端高亮的问题

### DIFF
--- a/packages/color-diff-napi/src/index.ts
+++ b/packages/color-diff-napi/src/index.ts
@@ -528,7 +528,7 @@ function highlightLine(
     // hljs throws on unknown language despite ignoreIllegals
     return [[defaultStyle(theme), code]]
   }
-  const emitter = result._emitter;
+  const emitter = result._emitter || {};
   if (!hasRootNode(emitter)) {
     if (!loggedEmitterShapeError) {
       loggedEmitterShapeError = true


### PR DESCRIPTION
highlight.js v11 `result = hljs().highlight();` 已经不存在result.emitter，使用result._emitter替代

### 修复之前
代码文件无高亮，全部为白色
<img width="672" height="621" alt="截屏2026-04-05 14 02 21" src="https://github.com/user-attachments/assets/ffc8bc34-3a3f-4746-94c8-b29c2c9d52d9" />

代码diff无高亮，全部为白色
<img width="681" height="467" alt="截屏2026-04-05 14 10 05" src="https://github.com/user-attachments/assets/0218db89-5772-44ed-a03b-ace8b3b86919" />

### 修复之后
代码文件可以正常高亮显示
<img width="544" height="442" alt="截屏2026-04-05 14 12 13" src="https://github.com/user-attachments/assets/b502b2eb-8804-4892-a974-d86151310b0b" />
代码diff 可以正常高亮显示
<img width="536" height="156" alt="截屏2026-04-05 14 12 49" src="https://github.com/user-attachments/assets/062032c6-a34c-4cfc-9e96-2bcca9480d7c" />

### 修复方案
方案一 highlight.js 依赖包降级到v10
方案二 修改 `packages/color-diff-napi/src/index.ts` result.emitter 为 result._emitter
<img width="480" height="409" alt="截屏2026-04-05 14 23 18" src="https://github.com/user-attachments/assets/852142a9-a235-4544-982b-d32e04cb2feb" />

或者，删除掉 `packages/color-diff-napi` 这个包，直接使用原代码中的的 `src/native-ts/color-diff/index.ts`，

```ts
// src/components/StructuredDiff/colorDiff.ts
import {
  ColorDiff,
  ColorFile,
  getSyntaxTheme as nativeGetSyntaxTheme,
  type SyntaxTheme,
} from 'color-diff-napi'

// 此处'color-diff-napi' 修改为 `'src/native-ts/color-diff/index.js'`
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal robustness improvements around syntax-highlighting internals, with clearer diagnostic messages when unexpected data is encountered.
  * No user-visible feature changes; behavior and UI remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->