### PR TITLE
fix: resolve absolute path in dev.ts for cross-directory execution

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -4,7 +4,15 @@
  * via Bun's -d flag (bunfig.toml [define] doesn't propagate to
  * dynamically imported modules at runtime).
  */
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { getMacroDefines } from "./defines.ts";
+
+// Resolve project root from this script's location
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = join(__dirname, "..");
+const cliPath = join(projectRoot, "src/entrypoints/cli.tsx");
 
 const defines = getMacroDefines();
 
@@ -32,8 +40,8 @@ const inspectArgs = process.env.BUN_INSPECT
     : [];
 
 const result = Bun.spawnSync(
-    ["bun", ...inspectArgs, "run", ...defineArgs, ...featureArgs, "src/entrypoints/cli.tsx", ...process.argv.slice(2)],
-    { stdio: ["inherit", "inherit", "inherit"] },
+    ["bun", ...inspectArgs, "run", ...defineArgs, ...featureArgs, cliPath, ...process.argv.slice(2)],
+    { stdio: ["inherit", "inherit", "inherit"], cwd: projectRoot },
 );
 
 process.exit(result.exitCode ?? 0);


### PR DESCRIPTION
The dev script previously used a relative path "src/entrypoints/cli.tsx" which would fail when executed from outside the project root directory.

Changes:
- Add path resolution using import.meta.url to locate project root
- Use absolute path for cli.tsx entry point
- Set cwd option in Bun.spawnSync to ensure correct working directory

This allows running "bun run /path/to/scripts/dev.ts" from any directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development script robustness by enhancing project root path resolution and working directory handling during development builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->