### PR TITLE
feat: enable Computer Use on Windows and Linux

### DIFF
--- a/packages/@ant/computer-use-input/src/index.ts
+++ b/packages/@ant/computer-use-input/src/index.ts
@@ -22,12 +22,18 @@ export interface InputBackend {
 }
 
 function loadBackend(): InputBackend | null {
-  if (process.platform !== 'darwin') return null
   try {
-    return require('./backends/darwin.js') as InputBackend
+    if (process.platform === 'darwin') {
+      return require('./backends/darwin.js') as InputBackend
+    } else if (process.platform === 'win32') {
+      return require('./backends/win32.js') as InputBackend
+    } else if (process.platform === 'linux') {
+      return require('./backends/linux.js') as InputBackend
+    }
   } catch {
     return null
   }
+  return null
 }
 
 const backend = loadBackend()

--- a/packages/@ant/computer-use-swift/src/index.ts
+++ b/packages/@ant/computer-use-swift/src/index.ts
@@ -18,19 +18,25 @@ export type {
 
 import type { ResolvePrepareCaptureResult } from './backends/darwin.js'
 
-function loadDarwin() {
-  if (process.platform !== 'darwin') return null
+function loadBackend() {
   try {
-    return require('./backends/darwin.js')
+    if (process.platform === 'darwin') {
+      return require('./backends/darwin.js')
+    } else if (process.platform === 'win32') {
+      return require('./backends/win32.js')
+    } else if (process.platform === 'linux') {
+      return require('./backends/linux.js')
+    }
   } catch {
     return null
   }
+  return null
 }
 
-const darwin = loadDarwin()
+const backend = loadBackend()
 
 export class ComputerUseAPI {
-  apps = darwin?.apps ?? {
+  apps = backend?.apps ?? {
     async prepareDisplay() { return { activated: '', hidden: [] } },
     async previewHideSet() { return [] },
     async findWindowDisplays(ids: string[]) { return ids.map((b: string) => ({ bundleId: b, displayIds: [] as number[] })) },
@@ -42,12 +48,12 @@ export class ComputerUseAPI {
     async unhide() {},
   }
 
-  display = darwin?.display ?? {
+  display = backend?.display ?? {
     getSize() { throw new Error('@ant/computer-use-swift: macOS only') },
     listAll() { throw new Error('@ant/computer-use-swift: macOS only') },
   }
 
-  screenshot = darwin?.screenshot ?? {
+  screenshot = backend?.screenshot ?? {
     async captureExcluding() { throw new Error('@ant/computer-use-swift: macOS only') },
     async captureRegion() { throw new Error('@ant/computer-use-swift: macOS only') },
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2434,7 +2434,7 @@ async function run(): Promise<CommanderCommand> {
       // shipped without incident; chicago places itself correctly.
       if (
         feature('CHICAGO_MCP') &&
-        getPlatform() === 'macos' &&
+        getPlatform() !== 'unknown' &&
         !getIsNonInteractiveSession()
       ) {
         try {

--- a/src/utils/computerUse/swiftLoader.ts
+++ b/src/utils/computerUse/swiftLoader.ts
@@ -7,9 +7,6 @@ let cached: ComputerUseAPI | undefined
  * Non-darwin platforms should use src/utils/computerUse/platforms/ instead.
  */
 export function requireComputerUseSwift(): ComputerUseAPI {
-  if (process.platform !== 'darwin') {
-    throw new Error('@ant/computer-use-swift is macOS-only. Use platforms/ for cross-platform.')
-  }
   if (cached) return cached
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const mod = require('@ant/computer-use-swift')


### PR DESCRIPTION
Remove macOS-only guards so Computer Use works cross-platform:
- main.tsx: allow CHICAGO_MCP on any known platform (not just macos)
- swiftLoader.ts: remove darwin-only throw, let the backend handle it
- computer-use-input: dispatch to darwin/win32/linux backends
- computer-use-swift: rename loadDarwin→loadBackend, dispatch all platforms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Computer Use functionality to support Windows and Linux platforms in addition to macOS.
  * Computer Use MCP feature is now available across all supported platforms with automatic platform-specific backend selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->