### PR TITLE
fix: add runtime fallback for MACRO when build-time defines are missing

### DIFF
--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -1,6 +1,20 @@
 #!/usr/bin/env bun
 import { feature } from 'bun:bundle'
 
+// Runtime fallback for MACRO.* when not injected by build/dev defines.
+// This happens when running cli.tsx directly (not via `bun run dev` or built dist/).
+if (typeof globalThis.MACRO === 'undefined') {
+  ;(globalThis as any).MACRO = {
+    VERSION: process.env.CLAUDE_CODE_VERSION || '2.1.888',
+    BUILD_TIME: new Date().toISOString(),
+    FEEDBACK_CHANNEL: '',
+    ISSUES_EXPLAINER: '',
+    NATIVE_PACKAGE_URL: '',
+    PACKAGE_URL: '',
+    VERSION_CHANGELOG: '',
+  }
+}
+
 // Bugfix for corepack auto-pinning, which adds yarnpkg to peoples' package.jsons
 // eslint-disable-next-line custom-rules/no-top-level-side-effects
 process.env.COREPACK_ENABLE_AUTO_PIN = '0'


### PR DESCRIPTION
## Summary
- Fixes `ReferenceError: MACRO is not defined` when running `cli.tsx` directly without build-time define injection (i.e., not via `bun run dev` or built `dist/cli.js`)
- Adds a `globalThis.MACRO` fallback at the top of `cli.tsx` that provides default values when Bun's `-d` flags or `Bun.build({ define })` haven't injected the MACRO namespace
- Version can be overridden via `CLAUDE_CODE_VERSION` env var

## Test plan
- [x] `bun run src/entrypoints/cli.tsx --version` → outputs `2.1.888 (Claude Code)` (previously crashed)
- [x] `bun run dev -- --version` → still works as before
- [ ] `bun run build && node dist/cli.js --version` → verify build path unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the `--version` command to work correctly across different build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->