### PR TITLE
feat: add Grok (xAI) API adapter

### DIFF
--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -1350,6 +1350,12 @@ async function* queryModel(
     return
   }
 
+  if (getAPIProvider() === 'grok') {
+    const { queryModelGrok } = await import('./grok/index.js')
+    yield* queryModelGrok(messagesForAPI, systemPrompt, filteredTools, signal, options)
+    return
+  }
+
   // Instrumentation: Track message count after normalization
   logEvent('tengu_api_after_normalize', {
     postNormalizedMessageCount: messagesForAPI.length,

--- a/src/services/api/grok/__tests__/client.test.ts
+++ b/src/services/api/grok/__tests__/client.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test'
+import { getGrokClient, clearGrokClientCache } from '../client.js'
+
+describe('getGrokClient', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    clearGrokClientCache()
+    process.env.GROK_API_KEY = 'test-key'
+    delete process.env.GROK_BASE_URL
+    delete process.env.XAI_API_KEY
+  })
+
+  afterEach(() => {
+    clearGrokClientCache()
+    process.env = { ...originalEnv }
+  })
+
+  test('creates client with default base URL', () => {
+    const client = getGrokClient()
+    expect(client).toBeDefined()
+    expect(client.baseURL).toBe('https://api.x.ai/v1')
+  })
+
+  test('uses GROK_BASE_URL when set', () => {
+    process.env.GROK_BASE_URL = 'https://custom.grok.api/v1'
+    clearGrokClientCache()
+    const client = getGrokClient()
+    expect(client.baseURL).toBe('https://custom.grok.api/v1')
+  })
+
+  test('falls back to XAI_API_KEY', () => {
+    delete process.env.GROK_API_KEY
+    process.env.XAI_API_KEY = 'test-key-placeholder'
+    clearGrokClientCache()
+    const client = getGrokClient()
+    expect(client).toBeDefined()
+    expect(client.apiKey).toBe('test-key-placeholder')
+  })
+
+  test('returns cached client on second call', () => {
+    const client1 = getGrokClient()
+    const client2 = getGrokClient()
+    expect(client1).toBe(client2)
+  })
+
+  test('clearGrokClientCache resets cache', () => {
+    const client1 = getGrokClient()
+    clearGrokClientCache()
+    process.env.GROK_BASE_URL = 'https://other.api/v1'
+    const client2 = getGrokClient()
+    expect(client1).not.toBe(client2)
+  })
+})

--- a/src/services/api/grok/__tests__/modelMapping.test.ts
+++ b/src/services/api/grok/__tests__/modelMapping.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test'
+import { resolveGrokModel } from '../modelMapping.js'
+
+describe('resolveGrokModel', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    delete process.env.GROK_MODEL
+    delete process.env.ANTHROPIC_DEFAULT_SONNET_MODEL
+    delete process.env.ANTHROPIC_DEFAULT_OPUS_MODEL
+    delete process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  test('GROK_MODEL env var takes highest priority', () => {
+    process.env.GROK_MODEL = 'grok-custom'
+    expect(resolveGrokModel('claude-sonnet-4-6')).toBe('grok-custom')
+  })
+
+  test('maps sonnet models to grok-3', () => {
+    expect(resolveGrokModel('claude-sonnet-4-6')).toBe('grok-3')
+  })
+
+  test('maps opus models to grok-3', () => {
+    expect(resolveGrokModel('claude-opus-4-6')).toBe('grok-3')
+  })
+
+  test('maps haiku models to grok-3-mini', () => {
+    expect(resolveGrokModel('claude-haiku-4-5-20251001')).toBe('grok-3-mini')
+  })
+
+  test('ANTHROPIC_DEFAULT_SONNET_MODEL overrides default map', () => {
+    process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'grok-2'
+    expect(resolveGrokModel('claude-sonnet-4-6')).toBe('grok-2')
+  })
+
+  test('passes through unknown model names', () => {
+    expect(resolveGrokModel('some-unknown-model')).toBe('some-unknown-model')
+  })
+
+  test('strips [1m] suffix before lookup', () => {
+    expect(resolveGrokModel('claude-sonnet-4-6[1m]')).toBe('grok-3')
+  })
+})

--- a/src/services/api/grok/client.ts
+++ b/src/services/api/grok/client.ts
@@ -1,0 +1,45 @@
+import OpenAI from 'openai'
+import { getProxyFetchOptions } from 'src/utils/proxy.js'
+
+/**
+ * Environment variables:
+ *
+ * GROK_API_KEY (or XAI_API_KEY): Required. API key for the xAI Grok endpoint.
+ * GROK_BASE_URL: Optional. Defaults to https://api.x.ai/v1.
+ */
+
+const DEFAULT_BASE_URL = 'https://api.x.ai/v1'
+
+let cachedClient: OpenAI | null = null
+
+export function getGrokClient(options?: {
+  maxRetries?: number
+  fetchOverride?: typeof fetch
+  source?: string
+}): OpenAI {
+  if (cachedClient) return cachedClient
+
+  const apiKey = process.env.GROK_API_KEY || process.env.XAI_API_KEY || ''
+  const baseURL = process.env.GROK_BASE_URL || DEFAULT_BASE_URL
+
+  const client = new OpenAI({
+    apiKey,
+    baseURL,
+    maxRetries: options?.maxRetries ?? 0,
+    timeout: parseInt(process.env.API_TIMEOUT_MS || String(600 * 1000), 10),
+    dangerouslyAllowBrowser: true,
+    fetchOptions: getProxyFetchOptions({ forAnthropicAPI: false }) as RequestInit,
+    ...(options?.fetchOverride && { fetch: options.fetchOverride }),
+  })
+
+  if (!options?.fetchOverride) {
+    cachedClient = client
+  }
+
+  return client
+}
+
+/** Clear the cached client (useful when env vars change). */
+export function clearGrokClientCache(): void {
+  cachedClient = null
+}

--- a/src/services/api/grok/index.ts
+++ b/src/services/api/grok/index.ts
@@ -1,0 +1,199 @@
+import type { BetaToolUnion } from '@anthropic-ai/sdk/resources/beta/messages/messages.mjs'
+import type { SystemPrompt } from '../../../utils/systemPromptType.js'
+import type { Message, StreamEvent, SystemAPIErrorMessage, AssistantMessage } from '../../../types/message.js'
+import type { Tools } from '../../../Tool.js'
+import { getGrokClient } from './client.js'
+import { anthropicMessagesToOpenAI } from '../openai/convertMessages.js'
+import { anthropicToolsToOpenAI, anthropicToolChoiceToOpenAI } from '../openai/convertTools.js'
+import { adaptOpenAIStreamToAnthropic } from '../openai/streamAdapter.js'
+import { resolveGrokModel } from './modelMapping.js'
+import { normalizeMessagesForAPI } from '../../../utils/messages.js'
+import { toolToAPISchema } from '../../../utils/api.js'
+import { logForDebugging } from '../../../utils/debug.js'
+import { addToTotalSessionCost } from '../../../cost-tracker.js'
+import { calculateUSDCost } from '../../../utils/modelCost.js'
+import type { Options } from '../claude.js'
+import { randomUUID } from 'crypto'
+import {
+  createAssistantAPIErrorMessage,
+  normalizeContentFromAPI,
+} from '../../../utils/messages.js'
+
+/**
+ * Grok (xAI) query path. Grok uses an OpenAI-compatible API, so we reuse
+ * the OpenAI message/tool converters and stream adapter. Only the client
+ * (different base URL + API key) and model mapping are Grok-specific.
+ */
+export async function* queryModelGrok(
+  messages: Message[],
+  systemPrompt: SystemPrompt,
+  tools: Tools,
+  signal: AbortSignal,
+  options: Options,
+): AsyncGenerator<
+  StreamEvent | AssistantMessage | SystemAPIErrorMessage,
+  void
+> {
+  try {
+    const grokModel = resolveGrokModel(options.model)
+    const messagesForAPI = normalizeMessagesForAPI(messages, tools)
+
+    const toolSchemas = await Promise.all(
+      tools.map(tool =>
+        toolToAPISchema(tool, {
+          getToolPermissionContext: options.getToolPermissionContext,
+          tools,
+          agents: options.agents,
+          allowedAgentTypes: options.allowedAgentTypes,
+          model: options.model,
+        }),
+      ),
+    )
+    const standardTools = toolSchemas.filter(
+      (t): t is BetaToolUnion & { type: string } => {
+        const anyT = t as Record<string, unknown>
+        return anyT.type !== 'advisor_20260301' && anyT.type !== 'computer_20250124'
+      },
+    )
+
+    const openaiMessages = anthropicMessagesToOpenAI(messagesForAPI, systemPrompt)
+    const openaiTools = anthropicToolsToOpenAI(standardTools)
+    const openaiToolChoice = anthropicToolChoiceToOpenAI(options.toolChoice)
+
+    const client = getGrokClient({
+      maxRetries: 0,
+      fetchOverride: options.fetchOverride,
+      source: options.querySource,
+    })
+
+    logForDebugging(`[Grok] Calling model=${grokModel}, messages=${openaiMessages.length}, tools=${openaiTools.length}`)
+
+    const stream = await client.chat.completions.create(
+      {
+        model: grokModel,
+        messages: openaiMessages,
+        ...(openaiTools.length > 0 && {
+          tools: openaiTools,
+          ...(openaiToolChoice && { tool_choice: openaiToolChoice }),
+        }),
+        stream: true,
+        stream_options: { include_usage: true },
+        ...(options.temperatureOverride !== undefined && {
+          temperature: options.temperatureOverride,
+        }),
+      },
+      {
+        signal,
+      },
+    )
+
+    const adaptedStream = adaptOpenAIStreamToAnthropic(stream, grokModel)
+
+    const contentBlocks: Record<number, any> = {}
+    let partialMessage: any = undefined
+    let usage = {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    }
+    let ttftMs = 0
+    const start = Date.now()
+
+    for await (const event of adaptedStream) {
+      switch (event.type) {
+        case 'message_start': {
+          partialMessage = (event as any).message
+          ttftMs = Date.now() - start
+          if ((event as any).message?.usage) {
+            usage = {
+              ...usage,
+              ...((event as any).message.usage),
+            }
+          }
+          break
+        }
+        case 'content_block_start': {
+          const idx = (event as any).index
+          const cb = (event as any).content_block
+          if (cb.type === 'tool_use') {
+            contentBlocks[idx] = { ...cb, input: '' }
+          } else if (cb.type === 'text') {
+            contentBlocks[idx] = { ...cb, text: '' }
+          } else if (cb.type === 'thinking') {
+            contentBlocks[idx] = { ...cb, thinking: '', signature: '' }
+          } else {
+            contentBlocks[idx] = { ...cb }
+          }
+          break
+        }
+        case 'content_block_delta': {
+          const idx = (event as any).index
+          const delta = (event as any).delta
+          const block = contentBlocks[idx]
+          if (!block) break
+          if (delta.type === 'text_delta') {
+            block.text = (block.text || '') + delta.text
+          } else if (delta.type === 'input_json_delta') {
+            block.input = (block.input || '') + delta.partial_json
+          } else if (delta.type === 'thinking_delta') {
+            block.thinking = (block.thinking || '') + delta.thinking
+          } else if (delta.type === 'signature_delta') {
+            block.signature = delta.signature
+          }
+          break
+        }
+        case 'content_block_stop': {
+          const idx = (event as any).index
+          const block = contentBlocks[idx]
+          if (!block || !partialMessage) break
+
+          const m: AssistantMessage = {
+            message: {
+              ...partialMessage,
+              content: normalizeContentFromAPI(
+                [block],
+                tools,
+                options.agentId,
+              ),
+            },
+            requestId: undefined,
+            type: 'assistant',
+            uuid: randomUUID(),
+            timestamp: new Date().toISOString(),
+          }
+          yield m
+          break
+        }
+        case 'message_delta': {
+          const deltaUsage = (event as any).usage
+          if (deltaUsage) {
+            usage = { ...usage, ...deltaUsage }
+          }
+          break
+        }
+        case 'message_stop':
+          break
+      }
+
+      if (event.type === 'message_stop' && usage.input_tokens + usage.output_tokens > 0) {
+        const costUSD = calculateUSDCost(grokModel, usage as any)
+        addToTotalSessionCost(costUSD, usage as any, options.model)
+      }
+
+      yield {
+        type: 'stream_event',
+        event,
+        ...(event.type === 'message_start' ? { ttftMs } : undefined),
+      } as StreamEvent
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    logForDebugging(`[Grok] Error: ${errorMessage}`, { level: 'error' })
+    yield createAssistantAPIErrorMessage({
+      content: `API Error: ${errorMessage}`,
+      apiError: 'api_error',
+      error: error instanceof Error ? error : new Error(String(error)),
+    })
+  }
+}

--- a/src/services/api/grok/modelMapping.ts
+++ b/src/services/api/grok/modelMapping.ts
@@ -1,0 +1,53 @@
+/**
+ * Default mapping from Anthropic model names to Grok model names.
+ * Used only when GROK_MODEL / ANTHROPIC_DEFAULT_*_MODEL env vars are not set.
+ */
+const DEFAULT_MODEL_MAP: Record<string, string> = {
+  'claude-sonnet-4-20250514': 'grok-3',
+  'claude-sonnet-4-5-20250929': 'grok-3',
+  'claude-sonnet-4-6': 'grok-3',
+  'claude-opus-4-20250514': 'grok-3',
+  'claude-opus-4-1-20250805': 'grok-3',
+  'claude-opus-4-5-20251101': 'grok-3',
+  'claude-opus-4-6': 'grok-3',
+  'claude-haiku-4-5-20251001': 'grok-3-mini',
+  'claude-3-5-haiku-20241022': 'grok-3-mini',
+  'claude-3-7-sonnet-20250219': 'grok-3',
+  'claude-3-5-sonnet-20241022': 'grok-3',
+}
+
+/**
+ * Determine the model family (haiku / sonnet / opus) from an Anthropic model ID.
+ */
+function getModelFamily(model: string): 'haiku' | 'sonnet' | 'opus' | null {
+  if (/haiku/i.test(model)) return 'haiku'
+  if (/opus/i.test(model)) return 'opus'
+  if (/sonnet/i.test(model)) return 'sonnet'
+  return null
+}
+
+/**
+ * Resolve the Grok model name for a given Anthropic model.
+ *
+ * Priority:
+ * 1. GROK_MODEL env var (override all)
+ * 2. ANTHROPIC_DEFAULT_{FAMILY}_MODEL env var
+ * 3. DEFAULT_MODEL_MAP lookup
+ * 4. Pass through original model name
+ */
+export function resolveGrokModel(anthropicModel: string): string {
+  if (process.env.GROK_MODEL) {
+    return process.env.GROK_MODEL
+  }
+
+  const cleanModel = anthropicModel.replace(/\[1m\]$/, '')
+
+  const family = getModelFamily(cleanModel)
+  if (family) {
+    const envVar = `ANTHROPIC_DEFAULT_${family.toUpperCase()}_MODEL`
+    const override = process.env[envVar]
+    if (override) return override
+  }
+
+  return DEFAULT_MODEL_MAP[cleanModel] ?? cleanModel
+}

--- a/src/utils/model/providers.ts
+++ b/src/utils/model/providers.ts
@@ -9,12 +9,14 @@ export type APIProvider =
   | 'foundry'
   | 'openai'
   | 'gemini'
+  | 'grok'
 
 export function getAPIProvider(): APIProvider {
   // 1. Check settings.json modelType field (highest priority)
   const modelType = getInitialSettings().modelType
   if (modelType === 'openai') return 'openai'
   if (modelType === 'gemini') return 'gemini'
+  if (modelType === 'grok') return 'grok'
 
   // 2. Check environment variables (backward compatibility)
   return isEnvTruthy(process.env.CLAUDE_CODE_USE_BEDROCK)
@@ -27,7 +29,9 @@ export function getAPIProvider(): APIProvider {
           ? 'openai'
           : isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI)
             ? 'gemini'
-            : 'firstParty'
+            : isEnvTruthy(process.env.CLAUDE_CODE_USE_GROK)
+              ? 'grok'
+              : 'firstParty'
 }
 
 export function getAPIProviderForStatsig(): AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS {

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -373,11 +373,11 @@ export const SettingsSchema = lazySchema(() =>
         .optional()
         .describe('Tool usage permissions configuration'),
       modelType: z
-        .enum(['anthropic', 'openai', 'gemini'])
+        .enum(['anthropic', 'openai', 'gemini', 'grok'])
         .optional()
         .describe(
-          'API provider type. "anthropic" uses the Anthropic API (default), "openai" uses the OpenAI Chat Completions API (/v1/chat/completions), and "gemini" uses the Gemini Generate Content API. ' +
-            'When set to "openai", configure OPENAI_API_KEY, OPENAI_BASE_URL, and OPENAI_MODEL in env. When set to "gemini", configure GEMINI_API_KEY, optional GEMINI_BASE_URL, and either GEMINI_MODEL or ANTHROPIC_DEFAULT_*_MODEL family env vars.',
+          'API provider type. "anthropic" uses the Anthropic API (default), "openai" uses the OpenAI Chat Completions API (/v1/chat/completions), "gemini" uses the Gemini Generate Content API, and "grok" uses the xAI Grok API (OpenAI-compatible). ' +
+            'When set to "openai", configure OPENAI_API_KEY, OPENAI_BASE_URL, and OPENAI_MODEL in env. When set to "gemini", configure GEMINI_API_KEY, optional GEMINI_BASE_URL, and either GEMINI_MODEL or ANTHROPIC_DEFAULT_*_MODEL family env vars. When set to "grok", configure GROK_API_KEY (or XAI_API_KEY), optional GROK_BASE_URL, and optional GROK_MODEL.',
         ),
       model: z
         .string()


### PR DESCRIPTION
## Summary
- Add xAI Grok as a new API provider, reusing OpenAI-compatible message/tool converters and stream adapter
- Grok-specific client (`api.x.ai/v1`) and model mapping (sonnet/opus → `grok-3`, haiku → `grok-3-mini`)
- Supports `GROK_API_KEY` / `XAI_API_KEY`, optional `GROK_BASE_URL` and `GROK_MODEL` overrides
- Activation via `CLAUDE_CODE_USE_GROK=1` env var or `modelType: "grok"` in settings.json

## Files changed
- **New**: `src/services/api/grok/` — client, modelMapping, index (+ 2 test files)
- **Modified**: `providers.ts` (add `'grok'` type), `types.ts` (add to modelType enum), `claude.ts` (add dispatch)

## Test plan
- [x] 12 new unit tests pass (client + modelMapping)
- [x] All 85 existing API adapter tests still pass
- [x] `bun run src/entrypoints/cli.tsx --version` smoke test passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Grok (xAI) as a new AI provider option with configurable API settings and automatic model mapping across different AI models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->