### PR TITLE
fix: resolve macOS Computer Use permission detection, app discovery, screenshot format, and image paste stall

### DIFF
--- a/packages/@ant/computer-use-swift/src/backends/darwin.ts
+++ b/packages/@ant/computer-use-swift/src/backends/darwin.ts
@@ -159,26 +159,34 @@ export const apps: AppsAPI = {
 
   async listInstalled() {
     try {
-      const result = await osascript(`
-        tell application "System Events"
-          set appList to ""
-          repeat with appFile in (every file of folder "Applications" of startup disk whose name ends with ".app")
-            set appPath to POSIX path of (appFile as alias)
-            set appName to name of appFile
-            set appList to appList & appPath & "|" & appName & "\\n"
-          end repeat
-          return appList
-        end tell
-      `)
-      return result.split('\n').filter(Boolean).map(line => {
-        const [path, name] = line.split('|', 2)
-        const displayName = (name ?? '').replace(/\.app$/, '')
-        return {
-          bundleId: `com.app.${displayName.toLowerCase().replace(/\s+/g, '-')}`,
-          displayName,
-          path: path ?? '',
+      // Use NSBundle via JXA ObjC bridge to read real CFBundleIdentifier.
+      // The old AppleScript used "every file of folder Applications" which
+      // misses .app bundles — packages are directories, not files on macOS.
+      const raw = await jxa(`
+        ObjC.import("Foundation");
+        var fm = $.NSFileManager.defaultManager;
+        var home = ObjC.unwrap($.NSHomeDirectory());
+        var searchDirs = ["/Applications", home + "/Applications"];
+        var result = [];
+        for (var d = 0; d < searchDirs.length; d++) {
+          var items = fm.contentsOfDirectoryAtPathError($(searchDirs[d]), null);
+          if (!items) continue;
+          for (var i = 0; i < items.count; i++) {
+            var name = ObjC.unwrap(items.objectAtIndex(i));
+            if (!name || !name.endsWith(".app")) continue;
+            var appPath = searchDirs[d] + "/" + name;
+            var bundle = $.NSBundle.bundleWithPath($(appPath));
+            if (!bundle) continue;
+            var bid = bundle.bundleIdentifier;
+            if (!bid) continue;
+            var bidStr = ObjC.unwrap(bid);
+            if (!bidStr) continue;
+            result.push({ bundleId: bidStr, displayName: name.slice(0, -4), path: appPath });
+          }
         }
-      })
+        JSON.stringify(result);
+      `)
+      return JSON.parse(raw) as InstalledApp[]
     } catch {
       return []
     }
@@ -226,33 +234,77 @@ export const apps: AppsAPI = {
 // ScreenshotAPI
 // ---------------------------------------------------------------------------
 
-async function captureScreenToBase64(args: string[]): Promise<{ base64: string; width: number; height: number }> {
-  const tmpFile = join(tmpdir(), `cu-screenshot-${Date.now()}.png`)
-  const proc = Bun.spawn(['screencapture', ...args, tmpFile], {
+/**
+ * Parse width/height from a JPEG buffer by scanning for the SOF0/SOF2 marker.
+ * Returns [0, 0] if parsing fails (caller should fall back to a separate query).
+ */
+function readJpegDimensions(buf: Buffer): [number, number] {
+  let i = 2 // skip SOI marker (FF D8)
+  while (i + 3 < buf.length) {
+    if (buf[i] !== 0xff) break
+    const marker = buf[i + 1]
+    const segLen = buf.readUInt16BE(i + 2)
+    // SOF markers: C0 (baseline), C1, C2 (progressive) — all have dims at same offsets
+    if ((marker >= 0xc0 && marker <= 0xc3) || (marker >= 0xc5 && marker <= 0xc7) ||
+        (marker >= 0xc9 && marker <= 0xcb) || (marker >= 0xcd && marker <= 0xcf)) {
+      // [2 len][1 precision][2 height][2 width]
+      const h = buf.readUInt16BE(i + 5)
+      const w = buf.readUInt16BE(i + 7)
+      return [w, h]
+    }
+    i += 2 + segLen
+  }
+  return [0, 0]
+}
+
+async function captureAndResizeToBase64(
+  captureArgs: string[],
+  targetW: number,
+  targetH: number,
+  quality: number,
+): Promise<{ base64: string; width: number; height: number }> {
+  const ts = Date.now()
+  const tmpPng = join(tmpdir(), `cu-screenshot-${ts}.png`)
+  const tmpJpeg = join(tmpdir(), `cu-screenshot-${ts}.jpg`)
+
+  const proc = Bun.spawn(['screencapture', ...captureArgs, tmpPng], {
     stdout: 'pipe', stderr: 'pipe',
   })
   await proc.exited
+
   try {
-    const buf = readFileSync(tmpFile)
+    // Resize to fit within targetW × targetH and convert to JPEG so the
+    // media type matches the hardcoded "image/jpeg" in toolCalls.ts.
+    // sips -Z scales the longest edge while preserving aspect ratio.
+    // formatOptions takes an integer 0-100 for JPEG quality.
+    const maxDim = Math.max(targetW, targetH)
+    const qualityInt = String(Math.round(quality * 100))
+    const sips = Bun.spawn(
+      ['sips', '-Z', String(maxDim), '-s', 'format', 'jpeg', '-s', 'formatOptions', qualityInt, tmpPng, '--out', tmpJpeg],
+      { stdout: 'pipe', stderr: 'pipe' },
+    )
+    await sips.exited
+
+    const buf = readFileSync(tmpJpeg)
     const base64 = buf.toString('base64')
-    const width = buf.readUInt32BE(16)
-    const height = buf.readUInt32BE(20)
+    const [width, height] = readJpegDimensions(buf)
     return { base64, width, height }
   } finally {
-    try { unlinkSync(tmpFile) } catch {}
+    try { unlinkSync(tmpPng) } catch {}
+    try { unlinkSync(tmpJpeg) } catch {}
   }
 }
 
 export const screenshot: ScreenshotAPI = {
-  async captureExcluding(_allowedBundleIds, _quality, _targetW, _targetH, displayId) {
+  async captureExcluding(_allowedBundleIds, quality, targetW, targetH, displayId) {
     const args = ['-x']
     if (displayId !== undefined) args.push('-D', String(displayId))
-    return captureScreenToBase64(args)
+    return captureAndResizeToBase64(args, targetW, targetH, quality)
   },
 
-  async captureRegion(_allowedBundleIds, x, y, w, h, _outW, _outH, _quality, displayId) {
+  async captureRegion(_allowedBundleIds, x, y, w, h, outW, outH, quality, displayId) {
     const args = ['-x', '-R', `${x},${y},${w},${h}`]
     if (displayId !== undefined) args.push('-D', String(displayId))
-    return captureScreenToBase64(args)
+    return captureAndResizeToBase64(args, outW, outH, quality)
   },
 }

--- a/packages/image-processor-napi/src/index.ts
+++ b/packages/image-processor-napi/src/index.ts
@@ -7,13 +7,13 @@ interface NativeModule {
   readClipboardImage(
     maxWidth?: number,
     maxHeight?: number,
-  ): {
+  ): Promise<{
     png: Buffer
     width: number
     height: number
     originalWidth: number
     originalHeight: number
-  } | null
+  } | null>
 }
 
 function createDarwinNativeModule(): NativeModule {
@@ -36,13 +36,14 @@ function createDarwinNativeModule(): NativeModule {
       }
     },
 
-    readClipboardImage(
+    async readClipboardImage(
       maxWidth?: number,
       maxHeight?: number,
     ) {
       try {
-        // Use osascript to read clipboard image as PNG data and write to a temp file,
-        // then read the temp file back
+        // Use async Bun.spawn (not spawnSync) so the event loop stays alive
+        // while osascript writes the clipboard PNG to disk. spawnSync blocks
+        // the main thread and freezes the Ink/React UI ("Pasting text…" stall).
         const tmpPath = `/tmp/claude_clipboard_native_${Date.now()}.png`
         const script = `
 set png_data to (the clipboard as «class PNGf»)
@@ -51,22 +52,19 @@ write png_data to fp
 close access fp
 return "${tmpPath}"
 `
-        const result = Bun.spawnSync({
-          cmd: ['osascript', '-e', script],
+        const proc = Bun.spawn(['osascript', '-e', script], {
           stdout: 'pipe',
           stderr: 'pipe',
         })
+        await proc.exited
 
-        if (result.exitCode !== 0) {
+        if (proc.exitCode !== 0) {
           return null
         }
 
-        const file = Bun.file(tmpPath)
-        // Use synchronous read via Node compat
-        const fs = require('fs')
+        const fs = require('fs') as typeof import('fs')
         const buffer: Buffer = fs.readFileSync(tmpPath)
 
-        // Clean up temp file
         try {
           fs.unlinkSync(tmpPath)
         } catch {
@@ -77,9 +75,7 @@ return "${tmpPath}"
           return null
         }
 
-        // Read PNG dimensions from IHDR chunk
-        // PNG header: 8 bytes signature, then IHDR chunk
-        // IHDR starts at offset 8 (4 bytes length) + 4 bytes "IHDR" + 4 bytes width + 4 bytes height
+        // Read PNG dimensions from IHDR chunk (offset 16/20).
         let width = 0
         let height = 0
         if (buffer.length > 24 && buffer[12] === 0x49 && buffer[13] === 0x48 && buffer[14] === 0x44 && buffer[15] === 0x52) {
@@ -90,9 +86,6 @@ return "${tmpPath}"
         const originalWidth = width
         const originalHeight = height
 
-        // If maxWidth/maxHeight are specified and the image exceeds them,
-        // we still return the full PNG - the caller handles resizing via sharp
-        // But we report the capped dimensions
         if (maxWidth && maxHeight) {
           if (width > maxWidth || height > maxHeight) {
             const scale = Math.min(maxWidth / width, maxHeight / height)
@@ -101,13 +94,7 @@ return "${tmpPath}"
           }
         }
 
-        return {
-          png: buffer,
-          width,
-          height,
-          originalWidth,
-          originalHeight,
-        }
+        return { png: buffer, width, height, originalWidth, originalHeight }
       } catch {
         return null
       }

--- a/src/hooks/usePasteHandler.ts
+++ b/src/hooks/usePasteHandler.ts
@@ -135,9 +135,17 @@ export function usePasteHandler({
                   pastedText,
                 )
 
-              // Process all image paths
+              // Process all image paths. Each path catches its own errors so
+              // Promise.all always resolves — ImageResizeError thrown by
+              // maybeResizeAndDownsampleImageBuffer would otherwise silently
+              // reject the whole chain and leave isPasting stuck at true.
               void Promise.all(
-                imagePaths.map(imagePath => tryReadImageFromPath(imagePath)),
+                imagePaths.map(imagePath =>
+                  tryReadImageFromPath(imagePath).catch(err => {
+                    logError(err as Error)
+                    return null
+                  }),
+                ),
               ).then(results => {
                 const validImages = results.filter(
                   (r): r is NonNullable<typeof r> => r !== null,
@@ -164,7 +172,8 @@ export function usePasteHandler({
                   }
                   setIsPasting(false)
                 } else if (isTempScreenshot && isMacOS) {
-                  // For temporary screenshot files that no longer exist, try clipboard
+                  // For temporary screenshot files that no longer exist, try clipboard.
+                  // checkClipboardForImage clears isPasting in its .finally().
                   checkClipboardForImage()
                 } else {
                   if (onPaste) {
@@ -172,6 +181,9 @@ export function usePasteHandler({
                   }
                   setIsPasting(false)
                 }
+              }).catch(() => {
+                // Safety net: clear isPasting even if .then() itself throws.
+                setIsPasting(false)
               })
               return { chunks: [], timeoutId: null }
             }

--- a/src/tools/FileReadTool/FileReadTool.ts
+++ b/src/tools/FileReadTool/FileReadTool.ts
@@ -1128,9 +1128,39 @@ export async function readImageWithTokenBudget(
       resized.dimensions,
     )
   } catch (e) {
-    if (e instanceof ImageResizeError) throw e
-    logError(e)
-    result = createImageResponse(imageBuffer, detectedFormat, originalSize)
+    if (e instanceof ImageResizeError) {
+      // Sharp failed on an oversized image. On macOS, try sips (built-in) as
+      // a fallback — it can resize+JPEG-convert any PNG without native deps.
+      if (process.platform === 'darwin') {
+        try {
+          const { tmpdir } = await import('os')
+          const { join: joinPath } = await import('path')
+          const { readFileSync, unlinkSync } = await import('fs')
+          const tmpOut = joinPath(tmpdir(), `claude-resize-${Date.now()}.jpg`)
+          const sips = Bun.spawn(
+            ['sips', '-Z', '1920', '-s', 'format', 'jpeg', '-s', 'formatOptions', '75',
+             filePath, '--out', tmpOut],
+            { stdout: 'pipe', stderr: 'pipe' },
+          )
+          await sips.exited
+          if (sips.exitCode === 0) {
+            const buf = readFileSync(tmpOut)
+            try { unlinkSync(tmpOut) } catch {}
+            result = createImageResponse(buf, 'jpeg', originalSize)
+          } else {
+            try { unlinkSync(tmpOut) } catch {}
+            result = createImageResponse(imageBuffer, detectedFormat, originalSize)
+          }
+        } catch {
+          result = createImageResponse(imageBuffer, detectedFormat, originalSize)
+        }
+      } else {
+        result = createImageResponse(imageBuffer, detectedFormat, originalSize)
+      }
+    } else {
+      logError(e)
+      result = createImageResponse(imageBuffer, detectedFormat, originalSize)
+    }
   }
 
   // Check if it fits in token budget
@@ -1174,6 +1204,27 @@ export async function readImageWithTokenBudget(
         return createImageResponse(fallbackBuffer, 'jpeg', originalSize)
       } catch (error) {
         logError(error)
+        // sips last resort (macOS): sharp is unavailable/broken, fall back to system tool
+        if (process.platform === 'darwin') {
+          try {
+            const { tmpdir } = await import('os')
+            const { join: joinPath } = await import('path')
+            const { readFileSync, unlinkSync } = await import('fs')
+            const tmpOut = joinPath(tmpdir(), `claude-resize-${Date.now()}.jpg`)
+            const sips = Bun.spawn(
+              ['sips', '-Z', '800', '-s', 'format', 'jpeg', '-s', 'formatOptions', '50',
+               filePath, '--out', tmpOut],
+              { stdout: 'pipe', stderr: 'pipe' },
+            )
+            await sips.exited
+            if (sips.exitCode === 0) {
+              const buf = readFileSync(tmpOut)
+              try { unlinkSync(tmpOut) } catch {}
+              return createImageResponse(buf, 'jpeg', originalSize)
+            }
+            try { unlinkSync(tmpOut) } catch {}
+          } catch {}
+        }
         return createImageResponse(imageBuffer, detectedFormat, originalSize)
       }
     }

--- a/src/utils/computerUse/escHotkey.ts
+++ b/src/utils/computerUse/escHotkey.ts
@@ -26,7 +26,7 @@ export function registerEscHotkey(onEscape: () => void): boolean {
   if (process.platform !== 'darwin') return false
   if (registered) return true
   const cu = requireComputerUseSwift()
-  if (!(cu as any).hotkey.registerEscape(onEscape)) {
+  if (!(cu as any).hotkey?.registerEscape?.(onEscape)) {
     // CGEvent.tapCreate failed — typically missing Accessibility permission.
     // CU still works, just without ESC abort. Mirrors Cowork's escAbort.ts:81.
     logForDebugging('[cu-esc] registerEscape returned false', { level: 'warn' })
@@ -41,7 +41,7 @@ export function registerEscHotkey(onEscape: () => void): boolean {
 export function unregisterEscHotkey(): void {
   if (!registered) return
   try {
-    (requireComputerUseSwift() as any).hotkey.unregister()
+    (requireComputerUseSwift() as any).hotkey?.unregister?.()
   } finally {
     releasePump()
     registered = false
@@ -51,5 +51,5 @@ export function unregisterEscHotkey(): void {
 
 export function notifyExpectedEscape(): void {
   if (!registered) return
-  (requireComputerUseSwift() as any).hotkey.notifyExpectedEscape()
+  (requireComputerUseSwift() as any).hotkey?.notifyExpectedEscape?.()
 }

--- a/src/utils/computerUse/hostAdapter.ts
+++ b/src/utils/computerUse/hostAdapter.ts
@@ -7,7 +7,6 @@ import { logForDebugging } from '../debug.js'
 import { COMPUTER_USE_MCP_SERVER_NAME } from './common.js'
 import { createCliExecutor } from './executor.js'
 import { getChicagoEnabled, getChicagoSubGates } from './gates.js'
-import { requireComputerUseSwift } from './swiftLoader.js'
 
 class DebugLogger implements Logger {
   silly(message: string, ...args: unknown[]): void {
@@ -46,12 +45,35 @@ export function getComputerUseHostAdapter(): ComputerUseHostAdapter {
     }),
     ensureOsPermissions: async () => {
       if (process.platform !== 'darwin') return { granted: true }
-      const cu = requireComputerUseSwift()
-      const accessibility = (cu as any).tcc.checkAccessibility()
-      const screenRecording = (cu as any).tcc.checkScreenRecording()
-      return accessibility && screenRecording
-        ? { granted: true }
-        : { granted: false, accessibility, screenRecording }
+      // Use Bun FFI to call TCC APIs in-process so macOS checks the CURRENT
+      // process's permissions (iTerm/Bun), not a subprocess like osascript.
+      // Same dlopen pattern as packages/modifiers-napi/src/index.ts.
+      try {
+        const ffi = require('bun:ffi') as typeof import('bun:ffi')
+
+        // AXIsProcessTrusted() — no args, checks accessibility for this process.
+        const axLib = ffi.dlopen(
+          '/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices',
+          { AXIsProcessTrusted: { args: [], returns: ffi.FFIType.bool } },
+        )
+        const accessibility = Boolean(axLib.symbols.AXIsProcessTrusted())
+        axLib.close()
+
+        // CGPreflightScreenCaptureAccess() — checks screen recording without prompting (macOS 11+).
+        const cgLib = ffi.dlopen(
+          '/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics',
+          { CGPreflightScreenCaptureAccess: { args: [], returns: ffi.FFIType.bool } },
+        )
+        const screenRecording = Boolean(cgLib.symbols.CGPreflightScreenCaptureAccess())
+        cgLib.close()
+
+        return accessibility && screenRecording
+          ? { granted: true }
+          : { granted: false, accessibility, screenRecording }
+      } catch {
+        // FFI unavailable (shouldn't happen on macOS with Bun) — assume granted.
+        return { granted: true }
+      }
     },
     isDisabled: () => !getChicagoEnabled(),
     getSubGates: getChicagoSubGates,

--- a/src/utils/imagePaste.ts
+++ b/src/utils/imagePaste.ts
@@ -143,7 +143,7 @@ export async function getImageFromClipboard(): Promise<ImageWithDimensions | nul
       if (!readClipboard) {
         throw new Error('native clipboard reader unavailable')
       }
-      const native = readClipboard(IMAGE_MAX_WIDTH, IMAGE_MAX_HEIGHT)
+      const native = await readClipboard(IMAGE_MAX_WIDTH, IMAGE_MAX_HEIGHT)
       if (!native) {
         return null
       }


### PR DESCRIPTION
## Summary

Fixes several macOS-specific bugs in the Computer Use MCP feature and image paste handling, discovered during real-world testing on macOS.

- **TCC permission detection uses Bun FFI in-process** — `ensureOsPermissions` was invoking `cu.tcc` via a subprocess, which checks the *subprocess's* TCC permissions (osascript), not the terminal's. Replaced with direct Bun FFI calls to `AXIsProcessTrusted()` and `CGPreflightScreenCaptureAccess()` so macOS evaluates the correct process.

- **App discovery reads real `CFBundleIdentifier`** — `listInstalled()` used AppleScript `every file of folder "Applications"` which silently skips `.app` bundles (they are directories on macOS, not files). Replaced with JXA ObjC bridge using `NSFileManager` + `NSBundle.bundleWithPath()`.

- **Screenshot pipeline produces correct JPEG** — `captureScreenToBase64` returned raw PNG bytes but `toolCalls.ts` hardcodes `mimeType: "image/jpeg"`, causing API 400 errors. Replaced with `captureAndResizeToBase64` that pipes `screencapture → sips -Z {maxDim} -s format jpeg`. Added `readJpegDimensions()` to parse JPEG SOF markers for accurate width/height.

- **ESC hotkey uses optional chaining** — `hotkey.registerEscape/unregister/notifyExpectedEscape` crashed when the `hotkey` namespace was absent (Accessibility not yet granted). Changed to `?.` optional chaining.

- **Clipboard image read is async** — `readClipboardImage` used `Bun.spawnSync` which blocks the event loop, freezing the Ink UI with a permanent "Pasting text…" indicator. Changed to `Bun.spawn` + `await proc.exited`.

- **`Promise.all` error isolation in paste handler** — `ImageResizeError` from one image path rejected the entire chain, preventing `setIsPasting(false)` from running. Added per-element `.catch(() => null)` and an outer `.catch` safety net.

- **FileReadTool compresses oversized images instead of erroring** — `readImageWithTokenBudget` re-threw `ImageResizeError` (sharp failed on oversized image) instead of compressing. Now falls back to `sips -Z 1920 -s format jpeg -s formatOptions 75`, with a second fallback at 800px/50% as last resort.

## Test plan

- [ ] CU permission dialog shows correct grant status from System Settings (not always "not granted")
- [ ] Installed apps (e.g. WeChat, Obsidian) appear with real bundle IDs
- [ ] CU screenshot returns valid JPEG without API 400 error
- [ ] `open_application` no longer crashes when Accessibility is not yet granted
- [ ] Pasting a large image completes without "Pasting text…" stall
- [ ] FileReadTool on a large screenshot path returns a compressed image instead of an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)