### PR TITLE
fix: 启动时 iTerm2 终端响应序列泄漏到 REPL 输入框

### DIFF
--- a/src/utils/earlyInput.ts
+++ b/src/utils/earlyInput.ts
@@ -102,17 +102,43 @@ function processChunk(str: string): void {
     }
 
     // Skip escape sequences (arrow keys, function keys, focus events, etc.)
-    // All escape sequences start with ESC (0x1B) and end with a byte in 0x40-0x7E
+    // All escape sequences start with ESC (0x1B).
     if (code === 27) {
       i++ // Skip the ESC character
-      // Skip until the terminating byte (@ to ~) or end of string
-      while (
-        i < str.length &&
-        !(str.charCodeAt(i) >= 64 && str.charCodeAt(i) <= 126)
-      ) {
-        i++
+      if (i >= str.length) continue
+
+      const next = str.charCodeAt(i)!
+
+      // CSI sequences: ESC [ ... <final_byte 0x40-0x7E>
+      // e.g. \x1b[?64;1;2;4;6;17;18;21;22c (DA1 response)
+      if (next === 0x5b /* [ */) {
+        i++ // skip '['
+        // Skip parameter bytes (0x30-0x3F) and intermediate bytes (0x20-0x2F)
+        while (i < str.length && str.charCodeAt(i)! >= 0x20 && str.charCodeAt(i)! <= 0x3f) {
+          i++
+        }
+        // Skip the final byte (0x40-0x7E)
+        if (i < str.length && str.charCodeAt(i)! >= 0x40 && str.charCodeAt(i)! <= 0x7e) i++
+        continue
       }
-      if (i < str.length) i++ // Skip the terminating byte
+
+      // String sequences: DCS (P), OSC (]), SOS (X), PM (^)
+      // These end with BEL (0x07) or ST (ESC \)
+      if (next === 0x50 /* P */ || next === 0x5d /* ] */ || next === 0x58 /* X */ || next === 0x5e /* ^ */) {
+        i++ // skip the introducer
+        while (i < str.length) {
+          if (str.charCodeAt(i) === 0x07) { i++; break } // BEL terminates
+          if (str.charCodeAt(i) === 0x1b && i + 1 < str.length && str.charCodeAt(i + 1)! === 0x5c) {
+            i += 2; break // ESC \ (ST) terminates
+          }
+          i++
+        }
+        continue
+      }
+
+      // SS2 (N), SS3 (O) — 2-byte sequences, just skip both
+      // Other simple escape sequences: ESC <byte 0x40-0x7E> — just skip the one byte
+      if (i < str.length) i++
       continue
     }
 


### PR DESCRIPTION
## Summary

- 修复 iTerm2 终端启动时 XTVERSION (DCS) 和 DA1 (CSI) 响应序列泄漏到 REPL 输入框的问题
- `src/utils/earlyInput.ts` 的 `processChunk()` 按 ECMA-48 标准正确处理 CSI、DCS、OSC、SOS、PM 转义序列

## 问题

在 iTerm2 中 `bun run dev` 启动后，REPL 输入框自动出现垃圾字符：

```
>|iTerm2 3.6.4?64;1;2;4;6;17;18;21;22c
```

原因是 `processChunk()` 的转义序列跳过逻辑过于简单，只检查 ESC 后第一个字节是否在 0x40-0x7E，导致 DCS (`\x1bP>|iTerm2 3.6.4\x1b\\`) 和 CSI (`\x1b[?64;...c`) 的有效载荷泄漏。

## 修复

按 ECMA-48 标准分别处理：
- **CSI** (`ESC [`): 跳过参数/中间字节 + 最终字节
- **DCS/OSC/SOS/PM** (`ESC P/]/X/^`): 扫描到 BEL 或 ST 终止符
- **其他**: 保持单字节跳过

## Test plan

- [ ] iTerm2 中运行 `bun run dev`，确认输入框无垃圾字符
- [ ] 输入 `hello world` 确认正常输入捕获不受影响
- [ ] 在 Terminal.app / WezTerm / kitty 等终端验证无回归

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of input processing by refining how special character sequences are handled.
  * Added protective checks to prevent potential reading errors when processing certain input patterns.
  * Enhanced parsing logic for better accuracy in recognizing and processing formatted input sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->