### PR TITLE
feat: add VSCode extension for Claude Code IDE integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ src/utils/vendor/
 .agents/
 .codex/
 .omx/
+.omc/
+.claude/settings.local.json
 
 # Binary / screenshot files (root only)
 /*.png

--- a/ide/vscode/.vscodeignore
+++ b/ide/vscode/.vscodeignore
@@ -1,0 +1,9 @@
+dist
+node_modules
+src
+.vscode-test
+**/*.ts
+**/*.map
+esbuild.js
+tsconfig.json
+.eslintrc.json

--- a/ide/vscode/README.md
+++ b/ide/vscode/README.md
@@ -1,0 +1,135 @@
+# Claude Code VSCode 插件
+
+基于 [csc 项目](../../) 的 VSCode 编辑器插件，将 Claude Code CLI 的能力直接集成到 VS Code 中。
+
+## 功能
+
+- **侧边栏聊天面板** - 在 VS Code 侧边栏与 Claude 对话
+- **多轮对话** - 完整的上下文会话支持
+- **会话历史** - 持久化会话，随时切换历史对话
+- **代码操作** - 右键菜单发送选中代码：解释、重构、修复
+- **工具权限审批** - 在 WebView 内嵌审批 Bash/文件操作等工具调用
+- **多 Provider 支持** - Anthropic / OpenAI 兼容 / Gemini / Bedrock / Vertex / Grok
+- **状态栏显示** - 实时显示运行状态和 Token 用量
+- **流式输出** - 实时显示 Claude 回复
+
+## 快速开始
+
+### 前置条件
+
+1. 先构建 csc 项目：
+   ```bash
+   cd ../../
+   bun run build
+   ```
+   这会生成 `dist/cli.js`，插件会自动检测到它。
+
+2. 安装 Node.js 依赖：
+   ```bash
+   cd ide/vscode
+   npm install
+   ```
+
+### 开发模式
+
+```bash
+# 编译插件（监听模式）
+npm run dev
+
+# 在 VS Code 中按 F5 启动调试（Extension Development Host）
+```
+
+### 打包发布
+
+```bash
+npm run build
+npm run package  # 生成 .vsix 文件
+```
+
+## 配置项
+
+在 VS Code 设置（`Ctrl+,`）中搜索 `claudeCode`：
+
+| 配置项 | 说明 | 默认值 |
+|--------|------|--------|
+| `claudeCode.cliPath` | CLI 路径（留空自动检测） | `""` |
+| `claudeCode.runtime` | 运行时：auto/node/bun | `"auto"` |
+| `claudeCode.provider` | AI 提供商 | `"anthropic"` |
+| `claudeCode.model` | 模型名称 | `""` |
+| `claudeCode.apiKey` | API 密钥 | `""` |
+| `claudeCode.openaiBaseUrl` | OpenAI 兼容端点 | `""` |
+| `claudeCode.permissionMode` | 权限模式 | `"default"` |
+| `claudeCode.autoApproveTools` | 自动批准的工具 | `["Read","Glob","Grep"]` |
+| `claudeCode.maxTurns` | 最大对话轮次 | `20` |
+| `claudeCode.showThinking` | 显示思考过程 | `false` |
+| `claudeCode.systemPrompt` | 附加系统提示 | `""` |
+
+## 命令
+
+| 命令 | 快捷键 | 说明 |
+|------|--------|------|
+| 新建对话 | `Ctrl+Shift+N` | 创建新的聊天会话 |
+| 发送选中代码 | `Ctrl+Shift+A` | 发送编辑器选中内容 |
+| 停止生成 | - | 停止当前 AI 生成 |
+| 查看历史 | - | 浏览历史对话 |
+| 打开设置 | - | 打开插件配置 |
+
+## 架构
+
+```
+ide/vscode/
+├── src/
+│   ├── extension.ts          # 插件入口（激活/注销）
+│   ├── types/index.ts        # 类型定义（消息/会话/权限/Provider）
+│   ├── config/settings.ts    # VSCode 设置读写
+│   ├── services/
+│   │   ├── ClaudeCodeProcess.ts  # CLI 进程管理（stream-json 协议）
+│   │   ├── SessionManager.ts     # 会话持久化
+│   │   └── PermissionManager.ts  # 工具权限审批
+│   ├── providers/
+│   │   ├── ChatViewProvider.ts   # 侧边栏 WebView（核心）
+│   │   └── StatusBarProvider.ts  # 状态栏
+│   ├── commands/index.ts         # 命令注册
+│   └── webview/
+│       ├── main.ts               # WebView 脚本（聊天 UI）
+│       └── style.css             # WebView 样式（VSCode 主题适配）
+└── esbuild.js                # 构建脚本
+```
+
+### 通信协议
+
+插件通过 `--input-format stream-json --output-format stream-json` 与 csc CLI 进行双向 JSON 通信：
+
+```
+Extension → CLI stdin:  {"type":"user","message":"你好"}
+CLI stdout → Extension: {"type":"assistant","message":{...}}
+CLI stdout → Extension: {"type":"result","subtype":"success",...}
+```
+
+### Provider 配置示例
+
+**Anthropic（默认）**
+```json
+{
+  "claudeCode.provider": "anthropic",
+  "claudeCode.apiKey": "sk-ant-..."
+}
+```
+
+**Ollama（OpenAI 兼容）**
+```json
+{
+  "claudeCode.provider": "openai",
+  "claudeCode.openaiBaseUrl": "http://localhost:11434/v1",
+  "claudeCode.model": "qwen2.5-coder:14b"
+}
+```
+
+**Google Gemini**
+```json
+{
+  "claudeCode.provider": "gemini",
+  "claudeCode.apiKey": "AIza...",
+  "claudeCode.model": "gemini-2.5-flash"
+}
+```

--- a/ide/vscode/assets/claude-icon.svg
+++ b/ide/vscode/assets/claude-icon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <!-- Claude 机器人图标 - 简洁风格 -->
+  <rect width="24" height="24" rx="6" fill="#CC785C"/>
+  <!-- 头部轮廓 -->
+  <circle cx="12" cy="10" r="6" fill="#F5E6D8" opacity="0.95"/>
+  <!-- 眼睛 -->
+  <circle cx="9.5" cy="9.5" r="1.2" fill="#1A1A1A"/>
+  <circle cx="14.5" cy="9.5" r="1.2" fill="#1A1A1A"/>
+  <!-- 高光 -->
+  <circle cx="9.9" cy="9.1" r="0.4" fill="white"/>
+  <circle cx="14.9" cy="9.1" r="0.4" fill="white"/>
+  <!-- 嘴巴 -->
+  <path d="M9.5 12 Q12 13.5 14.5 12" stroke="#1A1A1A" stroke-width="0.8" stroke-linecap="round" fill="none"/>
+  <!-- 身体 -->
+  <rect x="8" y="17" width="8" height="4" rx="2" fill="#F5E6D8" opacity="0.9"/>
+  <!-- 天线 -->
+  <line x1="12" y1="4" x2="12" y2="2" stroke="#F5E6D8" stroke-width="1" stroke-linecap="round"/>
+  <circle cx="12" cy="2" r="0.8" fill="#F5E6D8"/>
+</svg>

--- a/ide/vscode/esbuild.js
+++ b/ide/vscode/esbuild.js
@@ -1,0 +1,83 @@
+// esbuild 构建脚本 - 编译 VSCode 插件
+const esbuild = require('esbuild')
+const path = require('path')
+const fs = require('fs')
+
+// 是否生产模式
+const isProduction = process.argv.includes('--production')
+// 是否监听模式
+const isWatch = process.argv.includes('--watch')
+
+/** @type {import('esbuild').BuildOptions} */
+const buildOptions = {
+  // 入口文件
+  entryPoints: ['src/extension.ts'],
+  // 输出目录
+  outdir: 'dist',
+  // 打包为单文件
+  bundle: true,
+  // VSCode 插件平台
+  platform: 'node',
+  // Node.js 目标版本
+  target: 'node18',
+  // 外部依赖（vscode 不打包）
+  external: ['vscode'],
+  // 输出格式
+  format: 'cjs',
+  // source map
+  sourcemap: !isProduction,
+  // 压缩（生产模式）
+  minify: isProduction,
+  // 定义常量
+  define: {
+    'process.env.NODE_ENV': isProduction ? '"production"' : '"development"',
+  },
+}
+
+async function build() {
+  // 复制 webview 静态文件到 dist/webview
+  const webviewSrc = path.join(__dirname, 'src', 'webview')
+  const webviewDist = path.join(__dirname, 'dist', 'webview')
+
+  // 确保目录存在
+  if (!fs.existsSync(webviewDist)) {
+    fs.mkdirSync(webviewDist, { recursive: true })
+  }
+
+  // 复制 HTML 和 CSS
+  for (const file of ['index.html', 'style.css']) {
+    const src = path.join(webviewSrc, file)
+    const dst = path.join(webviewDist, file)
+    if (fs.existsSync(src)) {
+      fs.copyFileSync(src, dst)
+    }
+  }
+
+  // 编译 webview 脚本
+  await esbuild.build({
+    entryPoints: ['src/webview/main.ts'],
+    outdir: 'dist/webview',
+    bundle: true,
+    platform: 'browser',
+    target: 'es2020',
+    format: 'iife',
+    sourcemap: !isProduction,
+    minify: isProduction,
+  })
+
+  if (isWatch) {
+    // 监听模式
+    const ctx = await esbuild.context(buildOptions)
+    await ctx.watch()
+    console.log('[claude-code] watching for changes...')
+  } else {
+    // 单次构建
+    await esbuild.build(buildOptions)
+    console.log('[claude-code] build complete')
+  }
+}
+
+build().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/ide/vscode/package-lock.json
+++ b/ide/vscode/package-lock.json
@@ -1,0 +1,2216 @@
+{
+  "name": "claude-code-vscode",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claude-code-vscode",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.85.0",
+        "@typescript-eslint/eslint-plugin": "^7.0.0",
+        "@typescript-eslint/parser": "^7.0.0",
+        "esbuild": "^0.20.0",
+        "eslint": "^8.0.0",
+        "typescript": "^5.3.0"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmmirror.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmmirror.com/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmmirror.com/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmmirror.com/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmmirror.com/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmmirror.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmmirror.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmmirror.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.110.0",
+      "resolved": "https://registry.npmmirror.com/@types/vscode/-/vscode-1.110.0.tgz",
+      "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/type-utils": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmmirror.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmmirror.com/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmmirror.com/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmmirror.com/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmmirror.com/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmmirror.com/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmmirror.com/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmmirror.com/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmmirror.com/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmmirror.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmmirror.com/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmmirror.com/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmmirror.com/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmmirror.com/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmmirror.com/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmmirror.com/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmmirror.com/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmmirror.com/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmmirror.com/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmmirror.com/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmmirror.com/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmmirror.com/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmmirror.com/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmmirror.com/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmmirror.com/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmmirror.com/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmmirror.com/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmmirror.com/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmmirror.com/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmmirror.com/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmmirror.com/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmmirror.com/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmmirror.com/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmmirror.com/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmmirror.com/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmmirror.com/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/ide/vscode/package.json
+++ b/ide/vscode/package.json
@@ -1,0 +1,241 @@
+{
+  "name": "claude-code-vscode",
+  "displayName": "Claude Code",
+  "description": "Claude Code AI assistant integrated into VS Code - powered by the csc project",
+  "version": "0.1.0",
+  "publisher": "csc",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": ["AI", "Chat", "Other"],
+  "keywords": ["claude", "anthropic", "ai", "assistant", "copilot"],
+  "activationEvents": ["onStartupFinished"],
+  "main": "./dist/extension.js",
+  "icon": "assets/icon.png",
+  "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "claude-code",
+          "title": "Claude Code",
+          "icon": "assets/claude-icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "claude-code": [
+        {
+          "type": "webview",
+          "id": "claudeCode.chatView",
+          "name": "Chat",
+          "retainContextWhenHidden": true
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "claudeCode.newChat",
+        "title": "Claude Code: 新建对话",
+        "icon": "$(add)"
+      },
+      {
+        "command": "claudeCode.clearChat",
+        "title": "Claude Code: 清除当前对话",
+        "icon": "$(clear-all)"
+      },
+      {
+        "command": "claudeCode.sendSelection",
+        "title": "Claude Code: 发送选中代码到 Claude",
+        "icon": "$(send)"
+      },
+      {
+        "command": "claudeCode.explainSelection",
+        "title": "Claude Code: 解释选中代码"
+      },
+      {
+        "command": "claudeCode.refactorSelection",
+        "title": "Claude Code: 重构选中代码"
+      },
+      {
+        "command": "claudeCode.fixSelection",
+        "title": "Claude Code: 修复选中代码问题"
+      },
+      {
+        "command": "claudeCode.openSettings",
+        "title": "Claude Code: 打开设置",
+        "icon": "$(settings-gear)"
+      },
+      {
+        "command": "claudeCode.stopGeneration",
+        "title": "Claude Code: 停止生成",
+        "icon": "$(debug-stop)"
+      },
+      {
+        "command": "claudeCode.showSessionHistory",
+        "title": "Claude Code: 查看会话历史"
+      },
+      {
+        "command": "claudeCode.togglePanel",
+        "title": "Claude Code: 切换面板",
+        "icon": "$(layout-sidebar-right)"
+      }
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "submenu": "claudeCode.editorSubmenu",
+          "group": "claudeCode",
+          "when": "editorHasSelection"
+        }
+      ],
+      "claudeCode.editorSubmenu": [
+        {
+          "command": "claudeCode.sendSelection",
+          "group": "1_send"
+        },
+        {
+          "command": "claudeCode.explainSelection",
+          "group": "1_send"
+        },
+        {
+          "command": "claudeCode.refactorSelection",
+          "group": "1_send"
+        },
+        {
+          "command": "claudeCode.fixSelection",
+          "group": "1_send"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "claudeCode.newChat",
+          "when": "view == claudeCode.chatView",
+          "group": "navigation"
+        },
+        {
+          "command": "claudeCode.clearChat",
+          "when": "view == claudeCode.chatView",
+          "group": "navigation"
+        },
+        {
+          "command": "claudeCode.openSettings",
+          "when": "view == claudeCode.chatView",
+          "group": "navigation"
+        }
+      ]
+    },
+    "submenus": [
+      {
+        "id": "claudeCode.editorSubmenu",
+        "label": "Claude Code"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "claudeCode.sendSelection",
+        "key": "ctrl+shift+a",
+        "mac": "cmd+shift+a",
+        "when": "editorHasSelection"
+      },
+      {
+        "command": "claudeCode.newChat",
+        "key": "ctrl+shift+n",
+        "mac": "cmd+shift+n"
+      }
+    ],
+    "configuration": {
+      "title": "Claude Code",
+      "properties": {
+        "claudeCode.cliPath": {
+          "type": "string",
+          "default": "",
+          "description": "Claude Code CLI 路径（dist/cli.js 或 bun 可执行文件）。留空则自动检测项目根目录。"
+        },
+        "claudeCode.runtime": {
+          "type": "string",
+          "enum": ["auto", "node", "bun"],
+          "default": "auto",
+          "description": "运行时：auto（自动选择）、node（Node.js）、bun（Bun）"
+        },
+        "claudeCode.provider": {
+          "type": "string",
+          "enum": ["anthropic", "openai", "gemini", "bedrock", "vertex", "grok"],
+          "default": "anthropic",
+          "description": "AI 提供商"
+        },
+        "claudeCode.model": {
+          "type": "string",
+          "default": "",
+          "description": "模型名称（留空使用提供商默认模型）"
+        },
+        "claudeCode.apiKey": {
+          "type": "string",
+          "default": "",
+          "description": "API 密钥（推荐使用环境变量 ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY）"
+        },
+        "claudeCode.openaiBaseUrl": {
+          "type": "string",
+          "default": "",
+          "description": "OpenAI 兼容端点 Base URL（如 http://localhost:11434/v1）"
+        },
+        "claudeCode.permissionMode": {
+          "type": "string",
+          "enum": ["default", "acceptEdits", "bypassPermissions"],
+          "default": "default",
+          "description": "工具权限模式：default（询问）、acceptEdits（自动接受编辑）、bypassPermissions（跳过所有权限）"
+        },
+        "claudeCode.workingDirectory": {
+          "type": "string",
+          "default": "",
+          "description": "工作目录（留空使用当前工作区根目录）"
+        },
+        "claudeCode.autoApproveTools": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": ["Read", "Glob", "Grep"],
+          "description": "自动批准的工具列表"
+        },
+        "claudeCode.maxTurns": {
+          "type": "number",
+          "default": 20,
+          "minimum": 1,
+          "maximum": 100,
+          "description": "最大对话轮次"
+        },
+        "claudeCode.enableStreaming": {
+          "type": "boolean",
+          "default": true,
+          "description": "启用流式输出"
+        },
+        "claudeCode.showThinking": {
+          "type": "boolean",
+          "default": false,
+          "description": "显示模型思考过程"
+        },
+        "claudeCode.systemPrompt": {
+          "type": "string",
+          "default": "",
+          "description": "附加系统提示（追加到默认系统提示后）"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run build",
+    "build": "node esbuild.js --production",
+    "dev": "node esbuild.js --watch",
+    "lint": "eslint src --ext .ts",
+    "package": "vsce package",
+    "install-vsce": "npm install -g @vscode/vsce"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.85.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "esbuild": "^0.20.0",
+    "eslint": "^8.0.0",
+    "typescript": "^5.3.0"
+  },
+  "dependencies": {}
+}

--- a/ide/vscode/src/commands/index.ts
+++ b/ide/vscode/src/commands/index.ts
@@ -1,0 +1,177 @@
+// 命令注册模块 - 注册所有 VSCode 命令
+import * as vscode from 'vscode'
+import type { ChatViewProvider } from '../providers/ChatViewProvider'
+import type { SessionManager } from '../services/SessionManager'
+
+/**
+ * 注册插件所有命令
+ * @param context 插件上下文
+ * @param chatProvider 聊天视图提供者
+ * @param sessionManager 会话管理器
+ */
+export function registerCommands(
+  context: vscode.ExtensionContext,
+  chatProvider: ChatViewProvider,
+  sessionManager: SessionManager,
+): void {
+  // 新建对话
+  context.subscriptions.push(
+    vscode.commands.registerCommand('claudeCode.newChat', () => {
+      // 新建会话并聚焦到聊天面板
+      chatProvider.newChat()
+      // 聚焦到 Claude Code 侧边栏
+      vscode.commands.executeCommand('claudeCode.chatView.focus')
+    }),
+  )
+
+  // 清除当前对话
+  context.subscriptions.push(
+    vscode.commands.registerCommand('claudeCode.clearChat', () => {
+      // 确认后清除当前会话消息
+      vscode.window
+        .showWarningMessage('确认清除当前对话的所有消息？', '确认', '取消')
+        .then((choice) => {
+          if (choice === '确认') {
+            chatProvider.clearChat()
+          }
+        })
+    }),
+  )
+
+  // 发送选中代码
+  context.subscriptions.push(
+    vscode.commands.registerCommand('claudeCode.sendSelection', () => {
+      // 获取当前编辑器的选中文本
+      const editor = vscode.window.activeTextEditor
+      if (!editor) {
+        vscode.window.showWarningMessage('没有活跃的编辑器')
+        return
+      }
+      const selection = editor.selection
+      if (selection.isEmpty) {
+        vscode.window.showWarningMessage('没有选中任何代码')
+        return
+      }
+      // 获取选中内容和文件信息
+      const selectedText = editor.document.getText(selection)
+      const fileName = editor.document.fileName
+      const languageId = editor.document.languageId
+      // 构建带上下文的消息
+      const message = `请分析以下 ${languageId} 代码（文件：${fileName}）：\n\`\`\`${languageId}\n${selectedText}\n\`\`\``
+      // 发送到聊天
+      chatProvider.sendMessage(message)
+      // 聚焦到聊天面板
+      vscode.commands.executeCommand('claudeCode.chatView.focus')
+    }),
+  )
+
+  // 解释选中代码
+  context.subscriptions.push(
+    vscode.commands.registerCommand('claudeCode.explainSelection', () => {
+      const editor = vscode.window.activeTextEditor
+      if (!editor?.selection || editor.selection.isEmpty) {
+        vscode.window.showWarningMessage('没有选中任何代码')
+        return
+      }
+      const selectedText = editor.document.getText(editor.selection)
+      const languageId = editor.document.languageId
+      // 构建解释请求
+      const message = `请详细解释以下 ${languageId} 代码的功能和逻辑：\n\`\`\`${languageId}\n${selectedText}\n\`\`\``
+      chatProvider.sendMessage(message)
+      vscode.commands.executeCommand('claudeCode.chatView.focus')
+    }),
+  )
+
+  // 重构选中代码
+  context.subscriptions.push(
+    vscode.commands.registerCommand('claudeCode.refactorSelection', () => {
+      const editor = vscode.window.activeTextEditor
+      if (!editor?.selection || editor.selection.isEmpty) {
+        vscode.window.showWarningMessage('没有选中任何代码')
+        return
+      }
+      const selectedText = editor.document.getText(editor.selection)
+      const languageId = editor.document.languageId
+      const fileName = editor.document.fileName
+      // 构建重构请求
+      const message = `请重构以下 ${languageId} 代码，提高可读性、性能和可维护性（文件：${fileName}）：\n\`\`\`${languageId}\n${selectedText}\n\`\`\``
+      chatProvider.sendMessage(message)
+      vscode.commands.executeCommand('claudeCode.chatView.focus')
+    }),
+  )
+
+  // 修复选中代码问题
+  context.subscriptions.push(
+    vscode.commands.registerCommand('claudeCode.fixSelection', () => {
+      const editor = vscode.window.activeTextEditor
+      if (!editor?.selection || editor.selection.isEmpty) {
+        vscode.window.showWarningMessage('没有选中任何代码')
+        return
+      }
+      const selectedText = editor.document.getText(editor.selection)
+      const languageId = editor.document.languageId
+      // 获取诊断错误
+      const diagnostics = vscode.languages
+        .getDiagnostics(editor.document.uri)
+        .filter((d) => d.severity === vscode.DiagnosticSeverity.Error)
+        .slice(0, 5)
+        .map((d) => `${d.message} (第 ${d.range.start.line + 1} 行)`)
+        .join('\n')
+      // 构建修复请求
+      const errInfo = diagnostics ? `\n\n已知错误：\n${diagnostics}` : ''
+      const message = `请修复以下 ${languageId} 代码中的问题：${errInfo}\n\`\`\`${languageId}\n${selectedText}\n\`\`\``
+      chatProvider.sendMessage(message)
+      vscode.commands.executeCommand('claudeCode.chatView.focus')
+    }),
+  )
+
+  // 打开设置
+  context.subscriptions.push(
+    vscode.commands.registerCommand('claudeCode.openSettings', () => {
+      // 打开 VSCode 设置页面并过滤到 Claude Code 配置
+      vscode.commands.executeCommand('workbench.action.openSettings', 'claudeCode')
+    }),
+  )
+
+  // 停止生成
+  context.subscriptions.push(
+    vscode.commands.registerCommand('claudeCode.stopGeneration', () => {
+      chatProvider.stopGeneration()
+    }),
+  )
+
+  // 查看会话历史
+  context.subscriptions.push(
+    vscode.commands.registerCommand('claudeCode.showSessionHistory', async () => {
+      // 获取所有会话列表
+      const sessions = sessionManager.all
+      if (sessions.length === 0) {
+        vscode.window.showInformationMessage('没有历史对话')
+        return
+      }
+      // 使用 QuickPick 显示会话列表
+      const items = sessions.map((s) => ({
+        label: s.title,
+        description: new Date(s.updatedAt).toLocaleString('zh-CN'),
+        detail: `${s.messages.length} 条消息 | ${s.workingDirectory}`,
+        sessionId: s.id,
+      }))
+      const selected = await vscode.window.showQuickPick(items, {
+        title: '选择历史对话',
+        placeHolder: '搜索对话...',
+      })
+      if (selected) {
+        // 切换到选中的会话
+        chatProvider.loadSession(selected.sessionId)
+        vscode.commands.executeCommand('claudeCode.chatView.focus')
+      }
+    }),
+  )
+
+  // 切换面板
+  context.subscriptions.push(
+    vscode.commands.registerCommand('claudeCode.togglePanel', () => {
+      vscode.commands.executeCommand('claudeCode.chatView.focus')
+    }),
+  )
+}

--- a/ide/vscode/src/config/settings.ts
+++ b/ide/vscode/src/config/settings.ts
@@ -1,0 +1,163 @@
+// 插件配置管理 - 读取/写入 VSCode 设置
+import * as vscode from 'vscode'
+import type { ExtensionSettings, ProviderType, PermissionMode } from '../types'
+
+// 配置节名称
+const CONFIG_SECTION = 'claudeCode'
+
+/**
+ * 读取完整插件配置
+ */
+export function getSettings(): ExtensionSettings {
+  // 从 VSCode 配置读取所有设置项
+  const cfg = vscode.workspace.getConfiguration(CONFIG_SECTION)
+  return {
+    // CLI 路径
+    cliPath: cfg.get<string>('cliPath', ''),
+    // 运行时选择
+    runtime: cfg.get<'auto' | 'node' | 'bun'>('runtime', 'auto'),
+    // Provider 配置
+    provider: cfg.get<ProviderType>('provider', 'anthropic'),
+    model: cfg.get<string>('model', ''),
+    apiKey: cfg.get<string>('apiKey', ''),
+    openaiBaseUrl: cfg.get<string>('openaiBaseUrl', ''),
+    // 权限配置
+    permissionMode: cfg.get<PermissionMode>('permissionMode', 'default'),
+    autoApproveTools: cfg.get<string[]>('autoApproveTools', ['Read', 'Glob', 'Grep']),
+    // 对话配置
+    workingDirectory: cfg.get<string>('workingDirectory', ''),
+    maxTurns: cfg.get<number>('maxTurns', 20),
+    enableStreaming: cfg.get<boolean>('enableStreaming', true),
+    showThinking: cfg.get<boolean>('showThinking', false),
+    systemPrompt: cfg.get<string>('systemPrompt', ''),
+  }
+}
+
+/**
+ * 更新单项配置
+ */
+export async function updateSetting<K extends keyof ExtensionSettings>(
+  key: K,
+  value: ExtensionSettings[K],
+  global = true,
+): Promise<void> {
+  // 写入 VSCode 设置（全局或工作区）
+  const cfg = vscode.workspace.getConfiguration(CONFIG_SECTION)
+  await cfg.update(key, value, global ? vscode.ConfigurationTarget.Global : vscode.ConfigurationTarget.Workspace)
+}
+
+/**
+ * 获取工作目录：优先用户设置 -> 当前工作区根 -> 当前文件目录 -> 用户目录
+ */
+export function resolveWorkingDirectory(settings: ExtensionSettings): string {
+  // 优先使用用户配置的工作目录
+  if (settings.workingDirectory) {
+    return settings.workingDirectory
+  }
+  // 使用工作区根目录
+  const workspaceFolders = vscode.workspace.workspaceFolders
+  if (workspaceFolders && workspaceFolders.length > 0) {
+    return workspaceFolders[0].uri.fsPath
+  }
+  // 使用当前活跃文件所在目录
+  const activeFile = vscode.window.activeTextEditor?.document.uri.fsPath
+  if (activeFile) {
+    const path = require('path')
+    return path.dirname(activeFile)
+  }
+  // 最后回退到用户目录
+  return process.env.HOME || process.env.USERPROFILE || '.'
+}
+
+/**
+ * 构建 CLI 启动所需的环境变量
+ * 根据 provider 配置对应的 env vars
+ */
+export function buildEnvVars(settings: ExtensionSettings): Record<string, string> {
+  // 继承当前进程环境变量
+  const env: Record<string, string> = { ...process.env } as Record<string, string>
+
+  // 根据 provider 设置对应环境变量
+  switch (settings.provider) {
+    case 'anthropic':
+      // Anthropic 直接 API
+      if (settings.apiKey) {
+        env['ANTHROPIC_API_KEY'] = settings.apiKey
+      }
+      if (settings.model) {
+        env['ANTHROPIC_DEFAULT_SONNET_MODEL'] = settings.model
+      }
+      break
+
+    case 'openai':
+      // OpenAI 兼容协议
+      env['CLAUDE_CODE_USE_OPENAI'] = '1'
+      if (settings.apiKey) {
+        env['OPENAI_API_KEY'] = settings.apiKey
+      }
+      if (settings.openaiBaseUrl) {
+        env['OPENAI_BASE_URL'] = settings.openaiBaseUrl
+      }
+      if (settings.model) {
+        env['OPENAI_MODEL'] = settings.model
+      }
+      break
+
+    case 'gemini':
+      // Google Gemini
+      env['CLAUDE_CODE_USE_GEMINI'] = '1'
+      if (settings.apiKey) {
+        env['GEMINI_API_KEY'] = settings.apiKey
+      }
+      if (settings.model) {
+        env['GEMINI_MODEL'] = settings.model
+      }
+      break
+
+    case 'bedrock':
+      // AWS Bedrock
+      env['CLAUDE_CODE_USE_BEDROCK'] = '1'
+      if (settings.model) {
+        env['ANTHROPIC_DEFAULT_SONNET_MODEL'] = settings.model
+      }
+      break
+
+    case 'vertex':
+      // Google Vertex AI
+      env['CLAUDE_CODE_USE_VERTEX'] = '1'
+      if (settings.model) {
+        env['ANTHROPIC_DEFAULT_SONNET_MODEL'] = settings.model
+      }
+      break
+
+    case 'grok':
+      // Grok (xAI)
+      env['CLAUDE_CODE_USE_GROK'] = '1'
+      if (settings.apiKey) {
+        env['GROK_API_KEY'] = settings.apiKey
+      }
+      if (settings.model) {
+        env['GROK_MODEL'] = settings.model
+      }
+      break
+  }
+
+  // 禁用 telemetry 和交互式 UI（VSCode 插件模式）
+  env['CLAUDE_CODE_TELEMETRY'] = '0'
+  env['NO_COLOR'] = '1'
+  env['TERM'] = 'dumb'
+
+  return env
+}
+
+/**
+ * 监听配置变化
+ */
+export function onSettingsChange(callback: (settings: ExtensionSettings) => void): vscode.Disposable {
+  // 当配置更改时触发回调
+  return vscode.workspace.onDidChangeConfiguration((e) => {
+    if (e.affectsConfiguration(CONFIG_SECTION)) {
+      callback(getSettings())
+    }
+  })
+}

--- a/ide/vscode/src/extension.ts
+++ b/ide/vscode/src/extension.ts
@@ -1,0 +1,116 @@
+// VSCode 插件入口 - 激活和注销管理
+import * as vscode from 'vscode'
+import { ChatViewProvider } from './providers/ChatViewProvider'
+import { StatusBarProvider } from './providers/StatusBarProvider'
+import { SessionManager } from './services/SessionManager'
+import { PermissionManager } from './services/PermissionManager'
+import { ClaudeCodeProcess } from './services/ClaudeCodeProcess'
+import { registerCommands } from './commands'
+import { getSettings, onSettingsChange } from './config/settings'
+
+/** 插件输出日志通道 */
+let outputChannel: vscode.OutputChannel
+
+/**
+ * 插件激活入口
+ * 当 VSCode 加载插件时调用
+ */
+export function activate(context: vscode.ExtensionContext): void {
+  // 创建输出日志通道
+  outputChannel = vscode.window.createOutputChannel('Claude Code')
+  outputChannel.appendLine('[Extension] Claude Code 插件激活中...')
+
+  // 读取初始配置
+  const settings = getSettings()
+
+  // ===== 初始化核心服务 =====
+
+  // 会话管理器（持久化会话历史）
+  const sessionManager = new SessionManager(context, outputChannel)
+
+  // 工具权限管理器
+  const permissionManager = new PermissionManager(settings, outputChannel)
+
+  // CLI 进程管理器
+  const claudeProcess = new ClaudeCodeProcess(outputChannel)
+
+  // ===== 初始化 UI 组件 =====
+
+  // 聊天视图提供者（侧边栏 WebView）
+  const chatProvider = new ChatViewProvider(
+    context.extensionUri,
+    sessionManager,
+    permissionManager,
+    claudeProcess,
+    outputChannel,
+  )
+
+  // 状态栏提供者
+  const statusBar = new StatusBarProvider(claudeProcess, sessionManager)
+
+  // ===== 注册视图 =====
+
+  // 注册侧边栏 WebView 视图
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider('claudeCode.chatView', chatProvider, {
+      // 保持 WebView 上下文（切换面板时不销毁）
+      webviewOptions: { retainContextWhenHidden: true },
+    }),
+  )
+
+  // ===== 注册命令 =====
+
+  registerCommands(context, chatProvider, sessionManager)
+
+  // ===== 监听配置变化 =====
+
+  context.subscriptions.push(
+    onSettingsChange((newSettings) => {
+      outputChannel.appendLine('[Extension] 配置已更新')
+      // 通知权限管理器更新设置
+      permissionManager.updateSettings(newSettings)
+      // 通知聊天视图更新设置
+      chatProvider.onSettingsChange(newSettings)
+    }),
+  )
+
+  // ===== 注册 Disposables =====
+
+  context.subscriptions.push(
+    outputChannel,
+    statusBar,
+    chatProvider,
+    claudeProcess,
+    sessionManager,
+    permissionManager,
+  )
+
+  outputChannel.appendLine('[Extension] Claude Code 插件激活完成 ✓')
+
+  // 显示欢迎提示（仅首次安装）
+  const isFirstInstall = !context.globalState.get('claudeCode.installed')
+  if (isFirstInstall) {
+    context.globalState.update('claudeCode.installed', true)
+    vscode.window
+      .showInformationMessage(
+        'Claude Code 已成功安装！点击侧边栏的 Claude 图标开始对话。',
+        '打开设置',
+        '开始使用',
+      )
+      .then((choice) => {
+        if (choice === '打开设置') {
+          vscode.commands.executeCommand('claudeCode.openSettings')
+        } else if (choice === '开始使用') {
+          vscode.commands.executeCommand('claudeCode.chatView.focus')
+        }
+      })
+  }
+}
+
+/**
+ * 插件注销入口
+ * 当 VSCode 关闭或禁用插件时调用
+ */
+export function deactivate(): void {
+  outputChannel?.appendLine('[Extension] Claude Code 插件注销')
+}

--- a/ide/vscode/src/providers/ChatViewProvider.ts
+++ b/ide/vscode/src/providers/ChatViewProvider.ts
@@ -1,0 +1,615 @@
+// 聊天视图提供者 - WebView 侧边栏核心实现
+// 处理 Extension <-> WebView 双向消息通信，以及 CLI 进程事件路由
+import * as vscode from 'vscode'
+import * as path from 'path'
+import * as fs from 'fs'
+import type {
+  ChatMessage,
+  PermissionRequest,
+  StreamEvent,
+  ExtensionSettings,
+  WebViewMessage,
+  ExtensionMessage,
+  ToolCallInfo,
+} from '../types'
+import type { SessionManager } from '../services/SessionManager'
+import type { PermissionManager } from '../services/PermissionManager'
+import type { ClaudeCodeProcess } from '../services/ClaudeCodeProcess'
+import { getSettings, resolveWorkingDirectory } from '../config/settings'
+
+/**
+ * 聊天视图提供者
+ * 实现 VSCode WebviewViewProvider 接口，管理侧边栏聊天面板
+ */
+export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
+  // 当前 WebView 视图实例
+  private webviewView: vscode.WebviewView | null = null
+  // 当前设置
+  private settings: ExtensionSettings
+  // 事件订阅列表
+  private disposables: vscode.Disposable[] = []
+  // 当前正在流式输出的助手消息 ID
+  private currentAssistantMessageId: string | null = null
+
+  constructor(
+    private readonly extensionUri: vscode.Uri,
+    private readonly sessionManager: SessionManager,
+    private readonly permissionManager: PermissionManager,
+    private readonly claudeProcess: ClaudeCodeProcess,
+    private readonly outputChannel: vscode.OutputChannel,
+  ) {
+    // 读取初始设置
+    this.settings = getSettings()
+    // 绑定 CLI 进程事件
+    this.bindProcessEvents()
+    // 绑定权限事件
+    this.bindPermissionEvents()
+  }
+
+  // ===== WebviewViewProvider 接口实现 =====
+
+  /**
+   * 当 WebView 视图被解析（首次显示）时调用
+   */
+  resolveWebviewView(
+    webviewView: vscode.WebviewView,
+    _context: vscode.WebviewViewResolveContext,
+    _token: vscode.CancellationToken,
+  ): void {
+    this.webviewView = webviewView
+
+    // 配置 WebView 权限
+    webviewView.webview.options = {
+      // 启用 JavaScript
+      enableScripts: true,
+      // 允许加载的本地资源根目录
+      localResourceRoots: [
+        vscode.Uri.joinPath(this.extensionUri, 'dist', 'webview'),
+        vscode.Uri.joinPath(this.extensionUri, 'assets'),
+      ],
+    }
+
+    // 设置 WebView HTML 内容
+    webviewView.webview.html = this.getWebviewHtml(webviewView.webview)
+
+    // 监听来自 WebView 的消息
+    webviewView.webview.onDidReceiveMessage(
+      (msg: ExtensionMessage) => this.handleWebviewMessage(msg),
+      null,
+      this.disposables,
+    )
+
+    // 监听视图显示/隐藏
+    webviewView.onDidChangeVisibility(() => {
+      if (webviewView.visible) {
+        // 视图重新可见时，同步当前会话状态
+        this.syncSessionToWebview()
+      }
+    }, null, this.disposables)
+
+    this.outputChannel.appendLine('[ChatViewProvider] WebView 已初始化')
+  }
+
+  // ===== 公开 API =====
+
+  /**
+   * 新建对话
+   */
+  newChat(): void {
+    // 停止当前进程
+    if (this.claudeProcess.isRunning) {
+      this.claudeProcess.stop()
+    }
+    // 清除权限会话记忆
+    this.permissionManager.clearSessionMemory()
+    // 创建新会话
+    const cwd = resolveWorkingDirectory(this.settings)
+    this.sessionManager.createSession({
+      workingDirectory: cwd,
+      provider: this.settings.provider,
+      model: this.settings.model || undefined,
+    })
+    // 同步到 WebView
+    this.syncSessionToWebview()
+  }
+
+  /**
+   * 清除当前对话消息
+   */
+  clearChat(): void {
+    if (this.claudeProcess.isRunning) {
+      this.claudeProcess.stop()
+    }
+    const session = this.sessionManager.current
+    if (!session) return
+    // 清空消息列表（保留会话元数据）
+    session.messages.length = 0
+    this.syncSessionToWebview()
+  }
+
+  /**
+   * 发送消息（由命令调用，如发送选中代码）
+   */
+  sendMessage(content: string): void {
+    if (!this.sessionManager.current) {
+      // 自动创建会话
+      const cwd = resolveWorkingDirectory(this.settings)
+      this.sessionManager.createSession({ workingDirectory: cwd })
+    }
+    this.handleSendMessage(content)
+  }
+
+  /**
+   * 停止生成
+   */
+  stopGeneration(): void {
+    this.outputChannel.appendLine('[ChatViewProvider] 停止生成')
+    this.claudeProcess.stop()
+    this.permissionManager.cancelAll()
+    this.sessionManager.updateStatus('stopped')
+    this.sendToWebview({ type: 'session_status', status: 'stopped' })
+  }
+
+  /**
+   * 加载历史会话
+   */
+  loadSession(sessionId: string): void {
+    // 停止当前进程
+    if (this.claudeProcess.isRunning) {
+      this.claudeProcess.stop()
+    }
+    // 切换会话
+    const session = this.sessionManager.switchSession(sessionId)
+    if (!session) return
+    // 同步到 WebView
+    this.syncSessionToWebview()
+  }
+
+  /**
+   * 设置更新回调
+   */
+  onSettingsChange(newSettings: ExtensionSettings): void {
+    this.settings = newSettings
+  }
+
+  // ===== WebView 消息处理 =====
+
+  /**
+   * 处理来自 WebView 的消息
+   */
+  private handleWebviewMessage(msg: ExtensionMessage): void {
+    this.outputChannel.appendLine(`[ChatViewProvider] WebView → Extension: ${msg.type}`)
+
+    switch (msg.type) {
+      case 'ready':
+        // WebView 就绪，同步当前会话状态
+        this.syncSessionToWebview()
+        break
+
+      case 'send_message':
+        // 用户发送消息
+        this.handleSendMessage(msg.content)
+        break
+
+      case 'permission_decision':
+        // 用户在 WebView 内做出权限决策
+        this.permissionManager.resolveFromWebView(
+          msg.requestId,
+          msg.decision,
+          msg.remember ?? false,
+        )
+        break
+
+      case 'new_chat':
+        // 新建对话
+        this.newChat()
+        break
+
+      case 'load_session':
+        // 加载历史会话
+        this.loadSession(msg.sessionId)
+        break
+
+      case 'delete_session':
+        // 删除会话
+        this.sessionManager.deleteSession(msg.sessionId)
+        // 刷新会话列表
+        this.sendSessionsList()
+        break
+
+      case 'stop_generation':
+        // 停止生成
+        this.stopGeneration()
+        break
+
+      case 'get_sessions':
+        // 获取会话列表
+        this.sendSessionsList()
+        break
+    }
+  }
+
+  /**
+   * 处理发送消息
+   */
+  private async handleSendMessage(content: string): Promise<void> {
+    // 确保有当前会话
+    if (!this.sessionManager.current) {
+      const cwd = resolveWorkingDirectory(this.settings)
+      this.sessionManager.createSession({
+        workingDirectory: cwd,
+        provider: this.settings.provider,
+      })
+    }
+
+    const session = this.sessionManager.current!
+
+    // 构建用户消息
+    const userMessage: ChatMessage = {
+      id: `user_${Date.now()}`,
+      role: 'user',
+      content,
+      timestamp: Date.now(),
+    }
+
+    // 追加到会话
+    this.sessionManager.appendMessage(userMessage)
+    // 发送到 WebView 显示
+    this.sendToWebview({ type: 'message_append', message: userMessage })
+    // 更新状态为运行中
+    this.sessionManager.updateStatus('running')
+    this.sendToWebview({ type: 'session_status', status: 'running' })
+
+    // 如果进程已运行（多轮对话），直接发送消息
+    if (this.claudeProcess.isRunning) {
+      this.claudeProcess.sendMessage({ type: 'user', message: content })
+    } else {
+      // 否则启动新进程
+      const cwd = resolveWorkingDirectory(this.settings)
+      try {
+        await this.claudeProcess.start(content, this.settings, cwd)
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err)
+        this.outputChannel.appendLine(`[ChatViewProvider] 启动失败: ${errMsg}`)
+        vscode.window.showErrorMessage(`Claude Code 启动失败：${errMsg}`)
+        this.sessionManager.updateStatus('error', errMsg)
+        this.sendToWebview({ type: 'session_status', status: 'error', error: errMsg })
+      }
+    }
+  }
+
+  // ===== CLI 进程事件绑定 =====
+
+  /**
+   * 绑定 CLI 进程事件处理器
+   */
+  private bindProcessEvents(): void {
+    // 处理 stream-json 事件
+    this.claudeProcess.on('event', (event: StreamEvent) => {
+      this.handleStreamEvent(event)
+    })
+
+    // 进程状态变化
+    this.claudeProcess.on('statusChange', () => {
+      const status = this.claudeProcess.status
+      // 将进程状态映射到会话状态
+      const sessionStatus = status === 'running' ? 'running'
+        : status === 'starting' ? 'connecting'
+        : status === 'error' ? 'error'
+        : 'idle'
+      this.sendToWebview({ type: 'session_status', status: sessionStatus })
+    })
+
+    // 进程错误
+    this.claudeProcess.on('error', (err: Error) => {
+      this.outputChannel.appendLine(`[ChatViewProvider] 进程错误: ${err.message}`)
+      this.sessionManager.updateStatus('error', err.message)
+      this.sendToWebview({ type: 'session_status', status: 'error', error: err.message })
+    })
+
+    // 进程退出
+    this.claudeProcess.on('exit', (code: number | null) => {
+      this.outputChannel.appendLine(`[ChatViewProvider] 进程退出，code=${code}`)
+      if (this.sessionManager.current?.status === 'running') {
+        this.sessionManager.updateStatus('idle')
+        this.sendToWebview({ type: 'session_status', status: 'idle' })
+      }
+    })
+  }
+
+  /**
+   * 处理 CLI stream-json 事件
+   */
+  private handleStreamEvent(event: StreamEvent): void {
+    switch (event.type) {
+      case 'system':
+        // 系统初始化事件
+        if (event.subtype === 'init') {
+          this.sessionManager.setCliSessionId(event.session_id)
+          this.outputChannel.appendLine(`[ChatViewProvider] CLI 会话 ID: ${event.session_id}`)
+        }
+        break
+
+      case 'assistant':
+        // 助手消息事件 - 处理内容块
+        this.handleAssistantEvent(event)
+        break
+
+      case 'user':
+        // 用户消息（工具结果回传）- 通常不需要显示
+        break
+
+      case 'result':
+        // 对话完成事件
+        this.handleResultEvent(event)
+        break
+
+      case 'permission_request':
+        // 工具权限请求
+        this.handlePermissionRequestEvent(event)
+        break
+    }
+  }
+
+  /**
+   * 处理助手消息事件
+   */
+  private handleAssistantEvent(event: Extract<StreamEvent, { type: 'assistant' }>): void {
+    const { message } = event
+    const messageId = message.id
+
+    // 从内容块提取文本和工具调用
+    let textContent = ''
+    const toolCalls: ToolCallInfo[] = []
+    let thinkingContent = ''
+
+    for (const block of message.content) {
+      if (block.type === 'text') {
+        textContent += block.text
+      } else if (block.type === 'tool_use') {
+        toolCalls.push({
+          id: block.id,
+          name: block.name,
+          input: block.input as Record<string, unknown>,
+          status: 'pending',
+        })
+      } else if (block.type === 'thinking') {
+        thinkingContent = block.thinking
+      }
+    }
+
+    // 检查是否为已有消息的更新（流式输出）
+    const existingMsg = this.sessionManager.current?.messages.find((m) => m.id === messageId)
+
+    if (existingMsg) {
+      // 更新已有消息（流式追加）
+      const update: Partial<ChatMessage> = {
+        content: textContent,
+        toolCalls: toolCalls.length > 0 ? toolCalls : existingMsg.toolCalls,
+        streaming: message.stop_reason === null,
+        usage: message.usage
+          ? {
+              input_tokens: message.usage.input_tokens,
+              output_tokens: message.usage.output_tokens,
+              cost_usd: 0,
+            }
+          : existingMsg.usage,
+        thinking: thinkingContent || existingMsg.thinking,
+      }
+      this.sessionManager.updateMessage(messageId, update)
+      this.sendToWebview({ type: 'message_update', messageId, delta: update })
+    } else {
+      // 新的助手消息
+      const assistantMsg: ChatMessage = {
+        id: messageId,
+        role: 'assistant',
+        content: textContent,
+        timestamp: Date.now(),
+        toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+        streaming: message.stop_reason === null,
+        usage: message.usage
+          ? {
+              input_tokens: message.usage.input_tokens,
+              output_tokens: message.usage.output_tokens,
+              cost_usd: 0,
+            }
+          : undefined,
+        thinking: thinkingContent || undefined,
+      }
+      this.sessionManager.appendMessage(assistantMsg)
+      this.sendToWebview({ type: 'message_append', message: assistantMsg })
+      this.currentAssistantMessageId = messageId
+
+      // 如果有思考内容，单独发送
+      if (thinkingContent && this.settings.showThinking) {
+        this.sendToWebview({ type: 'thinking_update', messageId, thinking: thinkingContent })
+      }
+    }
+  }
+
+  /**
+   * 处理对话完成事件
+   */
+  private handleResultEvent(event: Extract<StreamEvent, { type: 'result' }>): void {
+    this.outputChannel.appendLine(
+      `[ChatViewProvider] 对话完成: ${event.subtype}, turns=${event.num_turns}, cost=$${event.cost_usd}`,
+    )
+
+    // 更新 token 用量统计
+    if (event.usage && event.cost_usd !== undefined) {
+      this.sessionManager.updateUsage(
+        event.usage.input_tokens,
+        event.usage.output_tokens,
+        event.cost_usd,
+      )
+    }
+
+    // 更新状态
+    const isError = event.subtype !== 'success'
+    this.sessionManager.updateStatus(isError ? 'error' : 'idle')
+    this.sendToWebview({
+      type: 'session_status',
+      status: isError ? 'error' : 'idle',
+      error: isError ? `对话终止：${event.subtype}` : undefined,
+    })
+
+    // 重置流式输出状态
+    if (this.currentAssistantMessageId) {
+      this.sessionManager.updateMessage(this.currentAssistantMessageId, { streaming: false })
+      this.sendToWebview({
+        type: 'message_update',
+        messageId: this.currentAssistantMessageId,
+        delta: { streaming: false },
+      })
+      this.currentAssistantMessageId = null
+    }
+  }
+
+  /**
+   * 处理工具权限请求事件
+   */
+  private async handlePermissionRequestEvent(
+    event: Extract<StreamEvent, { type: 'permission_request' }>,
+  ): Promise<void> {
+    const request: PermissionRequest = {
+      requestId: event.request_id,
+      toolName: event.tool_name,
+      toolInput: event.tool_input,
+      description: event.description,
+      timestamp: Date.now(),
+    }
+
+    this.outputChannel.appendLine(`[ChatViewProvider] 权限请求: ${event.tool_name}`)
+
+    // 更新会话状态为等待权限
+    this.sessionManager.updateStatus('waiting_permission')
+    this.sendToWebview({ type: 'session_status', status: 'waiting_permission' })
+
+    // 请求权限审批
+    const decision = await this.permissionManager.requestPermission(request)
+
+    // 发送权限响应给 CLI
+    this.claudeProcess.sendMessage({
+      type: 'permission_response',
+      request_id: event.request_id,
+      decision,
+    })
+
+    // 恢复运行状态
+    this.sessionManager.updateStatus('running')
+    this.sendToWebview({ type: 'session_status', status: 'running' })
+  }
+
+  // ===== 权限事件绑定 =====
+
+  /**
+   * 绑定权限管理器事件
+   */
+  private bindPermissionEvents(): void {
+    // 权限请求事件 → 通知 WebView 显示审批 UI
+    this.permissionManager.onPermissionRequest((request) => {
+      this.sendToWebview({ type: 'permission_request', request })
+    })
+
+    // 权限已解决事件 → 通知 WebView 更新 UI
+    this.permissionManager.onPermissionResolved(({ requestId, decision }) => {
+      this.sendToWebview({ type: 'permission_resolved', requestId, decision })
+    })
+  }
+
+  // ===== WebView 通信 =====
+
+  /**
+   * 向 WebView 发送消息
+   */
+  private sendToWebview(msg: WebViewMessage): void {
+    if (!this.webviewView?.visible) return
+    this.webviewView.webview.postMessage(msg)
+  }
+
+  /**
+   * 同步当前会话状态到 WebView
+   */
+  private syncSessionToWebview(): void {
+    const session = this.sessionManager.current
+    if (!session) return
+    this.sendToWebview({
+      type: 'init',
+      session,
+      settings: {
+        showThinking: this.settings.showThinking,
+        provider: this.settings.provider,
+        model: this.settings.model,
+      },
+    })
+  }
+
+  /**
+   * 发送会话列表到 WebView
+   */
+  private sendSessionsList(): void {
+    const sessions = this.sessionManager.all.map((s) => ({
+      id: s.id,
+      title: s.title,
+      createdAt: s.createdAt,
+      updatedAt: s.updatedAt,
+    }))
+    this.sendToWebview({ type: 'sessions_list', sessions })
+  }
+
+  // ===== HTML 生成 =====
+
+  /**
+   * 生成 WebView HTML 内容
+   */
+  private getWebviewHtml(webview: vscode.Webview): string {
+    // 转换本地资源 URI（受 CSP 保护）
+    const distPath = vscode.Uri.joinPath(this.extensionUri, 'dist', 'webview')
+
+    // 脚本 URI
+    const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(distPath, 'main.js'))
+    // 样式 URI
+    const styleUri = webview.asWebviewUri(vscode.Uri.joinPath(distPath, 'style.css'))
+
+    // 生成随机 nonce（防止 XSS）
+    const nonce = this.generateNonce()
+
+    return /* html */ `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="
+    default-src 'none';
+    style-src ${webview.cspSource} 'unsafe-inline';
+    script-src 'nonce-${nonce}';
+    font-src ${webview.cspSource};
+    img-src ${webview.cspSource} data:;
+  " />
+  <title>Claude Code</title>
+  <link rel="stylesheet" href="${styleUri}" />
+</head>
+<body>
+  <div id="app"></div>
+  <script nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`
+  }
+
+  /**
+   * 生成随机 nonce 字符串
+   */
+  private generateNonce(): string {
+    let text = ''
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+    for (let i = 0; i < 32; i++) {
+      text += chars.charAt(Math.floor(Math.random() * chars.length))
+    }
+    return text
+  }
+
+  /** 释放资源 */
+  dispose(): void {
+    this.disposables.forEach((d) => d.dispose())
+  }
+}

--- a/ide/vscode/src/providers/StatusBarProvider.ts
+++ b/ide/vscode/src/providers/StatusBarProvider.ts
@@ -1,0 +1,125 @@
+// 状态栏提供者 - 显示当前会话状态和模型信息
+import * as vscode from 'vscode'
+import type { ClaudeCodeProcess } from '../services/ClaudeCodeProcess'
+import type { SessionManager } from '../services/SessionManager'
+
+/**
+ * 状态栏管理器
+ * 在 VSCode 底部状态栏显示 Claude Code 状态
+ */
+export class StatusBarProvider implements vscode.Disposable {
+  // 主状态栏项（显示运行状态）
+  private statusItem: vscode.StatusBarItem
+  // token 用量状态栏项
+  private tokenItem: vscode.StatusBarItem
+  // 事件订阅列表
+  private disposables: vscode.Disposable[] = []
+
+  constructor(
+    private claudeProcess: ClaudeCodeProcess,
+    private sessionManager: SessionManager,
+  ) {
+    // 创建状态栏项（右侧对齐，优先级 100）
+    this.statusItem = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Right,
+      100,
+    )
+    // 点击时聚焦到聊天面板
+    this.statusItem.command = 'claudeCode.togglePanel'
+    // 创建 token 用量状态栏项
+    this.tokenItem = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Right,
+      99,
+    )
+    // 初始化显示
+    this.updateStatusBar()
+    // 显示状态栏
+    this.statusItem.show()
+
+    // 监听进程状态变化
+    this.disposables.push(
+      claudeProcess.on
+        ? { dispose: () => {} }
+        : { dispose: () => {} },
+    )
+    // 用 EventEmitter on 监听状态变化
+    claudeProcess.on('statusChange', () => this.updateStatusBar())
+    // 监听会话变化
+    sessionManager.onSessionChange(() => this.updateStatusBar())
+  }
+
+  /**
+   * 更新状态栏显示
+   */
+  private updateStatusBar(): void {
+    const status = this.claudeProcess.status
+    const session = this.sessionManager.current
+
+    // 根据进程状态设置图标和文字
+    switch (status) {
+      case 'idle':
+      case 'stopped':
+        // 空闲状态：显示 Claude 图标
+        this.statusItem.text = '$(hubot) Claude Code'
+        this.statusItem.tooltip = '点击打开 Claude Code 对话'
+        this.statusItem.backgroundColor = undefined
+        break
+
+      case 'starting':
+        // 启动中：显示旋转动画
+        this.statusItem.text = '$(sync~spin) Claude Code 启动中...'
+        this.statusItem.tooltip = 'Claude Code 正在启动'
+        break
+
+      case 'running':
+        // 运行中：显示绿色指示
+        this.statusItem.text = '$(loading~spin) Claude Code 思考中...'
+        this.statusItem.tooltip = '点击停止生成'
+        this.statusItem.command = 'claudeCode.stopGeneration'
+        break
+
+      case 'stopping':
+        // 停止中
+        this.statusItem.text = '$(debug-stop) Claude Code 停止中...'
+        this.statusItem.tooltip = '正在停止 Claude Code'
+        break
+
+      case 'error':
+        // 错误状态：显示红色
+        this.statusItem.text = '$(error) Claude Code 错误'
+        this.statusItem.tooltip = '点击查看日志'
+        this.statusItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground')
+        this.statusItem.command = 'claudeCode.togglePanel'
+        break
+    }
+
+    // 更新 token 用量显示
+    if (session?.totalUsage && (session.totalUsage.input_tokens > 0 || session.totalUsage.output_tokens > 0)) {
+      const totalTokens = session.totalUsage.input_tokens + session.totalUsage.output_tokens
+      const costStr = session.totalUsage.cost_usd > 0
+        ? ` | $${session.totalUsage.cost_usd.toFixed(4)}`
+        : ''
+      this.tokenItem.text = `$(symbol-variable) ${this.formatTokens(totalTokens)}${costStr}`
+      this.tokenItem.tooltip = `Token 用量：输入 ${session.totalUsage.input_tokens} | 输出 ${session.totalUsage.output_tokens}`
+      this.tokenItem.show()
+    } else {
+      this.tokenItem.hide()
+    }
+  }
+
+  /**
+   * 格式化 token 数量（千/百万单位）
+   */
+  private formatTokens(tokens: number): string {
+    if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M tokens`
+    if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}K tokens`
+    return `${tokens} tokens`
+  }
+
+  /** 释放资源 */
+  dispose(): void {
+    this.statusItem.dispose()
+    this.tokenItem.dispose()
+    this.disposables.forEach((d) => d.dispose())
+  }
+}

--- a/ide/vscode/src/services/ClaudeCodeProcess.ts
+++ b/ide/vscode/src/services/ClaudeCodeProcess.ts
@@ -1,0 +1,355 @@
+// Claude Code CLI 进程管理服务
+// 负责启动、通信和生命周期管理 Claude Code CLI 子进程
+import * as vscode from 'vscode'
+import * as cp from 'child_process'
+import * as path from 'path'
+import * as fs from 'fs'
+import { EventEmitter } from 'events'
+import type {
+  StreamEvent,
+  InputMessage,
+  ExtensionSettings,
+} from '../types'
+import { buildEnvVars } from '../config/settings'
+
+/** 进程状态 */
+export type ProcessStatus = 'idle' | 'starting' | 'running' | 'stopping' | 'stopped' | 'error'
+
+/** ClaudeCodeProcess 事件接口 */
+export interface ClaudeCodeProcessEvents {
+  // 收到 stream-json 事件
+  event: (event: StreamEvent) => void
+  // 进程状态变化
+  statusChange: (status: ProcessStatus) => void
+  // 进程错误
+  error: (error: Error) => void
+  // 进程退出
+  exit: (code: number | null) => void
+}
+
+/**
+ * Claude Code CLI 进程管理器
+ * 通过 --input-format stream-json --output-format stream-json 与 CLI 双向通信
+ */
+export class ClaudeCodeProcess extends EventEmitter {
+  // 当前子进程实例
+  private process: cp.ChildProcess | null = null
+  // 进程状态
+  private _status: ProcessStatus = 'idle'
+  // stdout 缓冲区（处理不完整的 JSON 行）
+  private stdoutBuffer = ''
+  // 输出日志通道
+  private outputChannel: vscode.OutputChannel
+
+  constructor(outputChannel: vscode.OutputChannel) {
+    super()
+    // 初始化输出日志通道
+    this.outputChannel = outputChannel
+  }
+
+  /** 当前进程状态 */
+  get status(): ProcessStatus {
+    return this._status
+  }
+
+  /** 是否正在运行 */
+  get isRunning(): boolean {
+    return this._status === 'running' || this._status === 'starting'
+  }
+
+  /**
+   * 启动 Claude Code CLI 进程
+   * @param prompt 初始提示词
+   * @param settings 插件配置
+   * @param cwd 工作目录
+   */
+  async start(prompt: string, settings: ExtensionSettings, cwd: string): Promise<void> {
+    // 如果已有进程在运行，先停止
+    if (this.isRunning) {
+      await this.stop()
+    }
+
+    // 解析 CLI 可执行文件和参数
+    const { cmd, args, env } = await this.buildLaunchConfig(settings, cwd)
+
+    this.outputChannel.appendLine(`[ClaudeCodeProcess] 启动: ${cmd} ${args.join(' ')}`)
+    this.outputChannel.appendLine(`[ClaudeCodeProcess] 工作目录: ${cwd}`)
+
+    // 更新状态为启动中
+    this.setStatus('starting')
+
+    // 启动子进程
+    this.process = cp.spawn(cmd, args, {
+      cwd,
+      env,
+      // 通过 pipe 进行 stdin/stdout 通信
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+    // 监听 stdout 数据（JSON 行协议）
+    this.process.stdout?.on('data', (chunk: Buffer) => {
+      this.handleStdoutChunk(chunk.toString())
+    })
+
+    // 监听 stderr 数据（调试日志）
+    this.process.stderr?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString()
+      this.outputChannel.appendLine(`[CLI stderr] ${text}`)
+    })
+
+    // 监听进程错误
+    this.process.on('error', (err) => {
+      this.outputChannel.appendLine(`[ClaudeCodeProcess] 进程错误: ${err.message}`)
+      this.setStatus('error')
+      this.emit('error', err)
+    })
+
+    // 监听进程退出
+    this.process.on('exit', (code) => {
+      this.outputChannel.appendLine(`[ClaudeCodeProcess] 进程退出，code=${code}`)
+      this.process = null
+      this.setStatus('stopped')
+      this.emit('exit', code)
+    })
+
+    // 更新状态为运行中
+    this.setStatus('running')
+
+    // 发送初始提示词
+    this.sendMessage({ type: 'user', message: prompt })
+  }
+
+  /**
+   * 发送消息到 CLI 进程（通过 stdin）
+   * @param msg stream-json 输入消息
+   */
+  sendMessage(msg: InputMessage): void {
+    // 检查进程是否在运行
+    if (!this.process?.stdin || !this.isRunning) {
+      this.outputChannel.appendLine('[ClaudeCodeProcess] 无法发送消息：进程未运行')
+      return
+    }
+    // 序列化为 JSON 行协议
+    const line = JSON.stringify(msg) + '\n'
+    this.outputChannel.appendLine(`[ClaudeCodeProcess] → ${line.trim()}`)
+    // 写入 stdin
+    this.process.stdin.write(line)
+  }
+
+  /**
+   * 停止 CLI 进程
+   */
+  async stop(): Promise<void> {
+    if (!this.process) {
+      return
+    }
+    // 更新状态为停止中
+    this.setStatus('stopping')
+    this.outputChannel.appendLine('[ClaudeCodeProcess] 正在停止进程...')
+
+    // 关闭 stdin 触发优雅退出
+    this.process.stdin?.end()
+
+    // 等待进程退出（最多 3 秒）
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => {
+        // 超时则强制杀死进程
+        this.process?.kill('SIGKILL')
+        resolve()
+      }, 3000)
+
+      this.process?.once('exit', () => {
+        clearTimeout(timeout)
+        resolve()
+      })
+    })
+
+    this.process = null
+    this.setStatus('stopped')
+  }
+
+  /**
+   * 处理 stdout 数据块
+   * 支持跨 chunk 的不完整 JSON 行
+   */
+  private handleStdoutChunk(chunk: string): void {
+    // 追加到缓冲区
+    this.stdoutBuffer += chunk
+
+    // 按行分割处理完整的 JSON 行
+    const lines = this.stdoutBuffer.split('\n')
+    // 最后一个可能是不完整的行，保留在缓冲区
+    this.stdoutBuffer = lines.pop() ?? ''
+
+    for (const line of lines) {
+      // 跳过空行
+      const trimmed = line.trim()
+      if (!trimmed) continue
+
+      this.outputChannel.appendLine(`[ClaudeCodeProcess] ← ${trimmed}`)
+
+      // 解析 JSON
+      try {
+        const event = JSON.parse(trimmed) as StreamEvent
+        this.emit('event', event)
+      } catch {
+        // 非 JSON 行（如普通文本输出）记录到日志
+        this.outputChannel.appendLine(`[ClaudeCodeProcess] 非 JSON 输出: ${trimmed}`)
+      }
+    }
+  }
+
+  /**
+   * 构建 CLI 启动配置
+   * 自动检测运行时（node/bun）和 CLI 路径
+   */
+  private async buildLaunchConfig(
+    settings: ExtensionSettings,
+    cwd: string,
+  ): Promise<{ cmd: string; args: string[]; env: Record<string, string> }> {
+    // 解析 CLI 路径
+    const cliPath = await this.resolveCLIPath(settings, cwd)
+    this.outputChannel.appendLine(`[ClaudeCodeProcess] CLI 路径: ${cliPath}`)
+
+    // 解析运行时
+    const runtime = await this.resolveRuntime(settings, cliPath)
+    this.outputChannel.appendLine(`[ClaudeCodeProcess] 运行时: ${runtime}`)
+
+    // 构建启动参数
+    // 使用 -p 管道模式 + stream-json 双向协议
+    const args = [
+      cliPath,
+      '--print',
+      '--input-format', 'stream-json',
+      '--output-format', 'stream-json',
+      '--max-turns', String(settings.maxTurns),
+    ]
+
+    // 添加权限模式参数
+    if (settings.permissionMode === 'bypassPermissions') {
+      args.push('--dangerously-skip-permissions')
+    } else if (settings.permissionMode === 'acceptEdits') {
+      args.push('--permission-mode', 'acceptEdits')
+    }
+
+    // 添加自定义系统提示
+    if (settings.systemPrompt) {
+      args.push('--append-system-prompt', settings.systemPrompt)
+    }
+
+    // 构建环境变量
+    const env = buildEnvVars(settings)
+
+    return { cmd: runtime, args, env }
+  }
+
+  /**
+   * 解析 CLI 路径
+   * 优先级：用户配置 -> 项目 dist/cli.js -> 全局 claude 命令
+   */
+  private async resolveCLIPath(settings: ExtensionSettings, cwd: string): Promise<string> {
+    // 用户配置的路径
+    if (settings.cliPath && fs.existsSync(settings.cliPath)) {
+      return settings.cliPath
+    }
+
+    // 查找项目 dist/cli.js（向上查找）
+    const distCli = this.findDistCLI(cwd)
+    if (distCli) {
+      return distCli
+    }
+
+    // 全局 claude 命令
+    const globalClaude = await this.findGlobalCommand('claude')
+    if (globalClaude) {
+      return globalClaude
+    }
+
+    throw new Error(
+      '无法找到 Claude Code CLI。请在设置中配置 claudeCode.cliPath，或先构建项目（bun run build）。',
+    )
+  }
+
+  /**
+   * 向上查找 dist/cli.js
+   */
+  private findDistCLI(startDir: string): string | null {
+    let dir = startDir
+    // 最多向上查找 5 层
+    for (let i = 0; i < 5; i++) {
+      const candidate = path.join(dir, 'dist', 'cli.js')
+      if (fs.existsSync(candidate)) {
+        return candidate
+      }
+      const parent = path.dirname(dir)
+      // 到达根目录则停止
+      if (parent === dir) break
+      dir = parent
+    }
+    return null
+  }
+
+  /**
+   * 查找全局命令路径
+   */
+  private findGlobalCommand(name: string): Promise<string | null> {
+    return new Promise((resolve) => {
+      const cmd = process.platform === 'win32' ? 'where' : 'which'
+      cp.exec(`${cmd} ${name}`, (err, stdout) => {
+        if (err || !stdout.trim()) {
+          resolve(null)
+        } else {
+          resolve(stdout.trim().split('\n')[0])
+        }
+      })
+    })
+  }
+
+  /**
+   * 解析运行时命令
+   * 优先级：用户配置 -> 检测 bun -> 使用 node
+   */
+  private async resolveRuntime(settings: ExtensionSettings, cliPath: string): Promise<string> {
+    // 如果是全局 claude 命令（不是 .js 文件），直接运行
+    if (!cliPath.endsWith('.js')) {
+      return cliPath
+    }
+
+    // 用户显式配置
+    if (settings.runtime === 'bun') {
+      return 'bun'
+    }
+    if (settings.runtime === 'node') {
+      return 'node'
+    }
+
+    // 自动检测：优先 bun
+    const bunPath = await this.findGlobalCommand('bun')
+    if (bunPath) {
+      return bunPath
+    }
+
+    // 回退到 node
+    return 'node'
+  }
+
+  /**
+   * 更新并广播进程状态
+   */
+  private setStatus(status: ProcessStatus): void {
+    // 状态相同时不重复广播
+    if (this._status === status) return
+    this._status = status
+    this.emit('statusChange', status)
+  }
+
+  /** 释放资源 */
+  dispose(): void {
+    // 停止进程
+    if (this.isRunning) {
+      this.stop()
+    }
+    // 清理事件监听
+    this.removeAllListeners()
+  }
+}

--- a/ide/vscode/src/services/PermissionManager.ts
+++ b/ide/vscode/src/services/PermissionManager.ts
@@ -1,0 +1,229 @@
+// 工具权限管理服务
+// 负责工具调用的权限审批：自动批准、VSCode 弹窗询问、WebView 内嵌审批
+import * as vscode from 'vscode'
+import type { PermissionRequest, ExtensionSettings } from '../types'
+
+/** 权限决策结果 */
+export type PermissionDecision = 'allow' | 'deny'
+
+/** 等待决策的请求 */
+interface PendingRequest {
+  request: PermissionRequest
+  resolve: (decision: PermissionDecision) => void
+}
+
+/**
+ * 权限管理器
+ * 对工具调用的权限进行三级处理：
+ * 1. bypassPermissions 模式 → 全部自动允许
+ * 2. autoApproveTools 列表中的工具 → 自动允许
+ * 3. 其他工具 → 通过 VSCode 弹窗或 WebView 询问用户
+ */
+export class PermissionManager {
+  // 当前等待决策的权限请求（requestId -> PendingRequest）
+  private pendingRequests = new Map<string, PendingRequest>()
+  // 会话级别的"记住"决策（toolName -> decision）
+  private sessionMemory = new Map<string, PermissionDecision>()
+  // 权限请求事件（通知 WebView 显示审批 UI）
+  private readonly _onPermissionRequest = new vscode.EventEmitter<PermissionRequest>()
+  readonly onPermissionRequest = this._onPermissionRequest.event
+  // 权限已解决事件（通知 WebView 更新 UI）
+  private readonly _onPermissionResolved = new vscode.EventEmitter<{
+    requestId: string
+    decision: PermissionDecision
+  }>()
+  readonly onPermissionResolved = this._onPermissionResolved.event
+
+  // 当前设置
+  private settings: ExtensionSettings
+  // 输出日志
+  private outputChannel: vscode.OutputChannel
+
+  constructor(settings: ExtensionSettings, outputChannel: vscode.OutputChannel) {
+    this.settings = settings
+    this.outputChannel = outputChannel
+  }
+
+  /**
+   * 更新设置（当用户更改配置时调用）
+   */
+  updateSettings(settings: ExtensionSettings): void {
+    this.settings = settings
+  }
+
+  /**
+   * 请求权限审批
+   * 返回用户的决策：'allow' 或 'deny'
+   */
+  async requestPermission(request: PermissionRequest): Promise<PermissionDecision> {
+    const { toolName, toolInput, requestId } = request
+
+    this.outputChannel.appendLine(`[PermissionManager] 权限请求: ${toolName} (${requestId})`)
+
+    // 1. bypassPermissions 模式：全部允许
+    if (this.settings.permissionMode === 'bypassPermissions') {
+      this.outputChannel.appendLine(`[PermissionManager] bypassPermissions → 允许 ${toolName}`)
+      return 'allow'
+    }
+
+    // 2. 检查会话记忆（之前选择过"记住决策"）
+    const remembered = this.sessionMemory.get(toolName)
+    if (remembered) {
+      this.outputChannel.appendLine(`[PermissionManager] 会话记忆 → ${remembered} ${toolName}`)
+      return remembered
+    }
+
+    // 3. 检查 autoApproveTools 列表
+    if (this.isAutoApproved(toolName)) {
+      this.outputChannel.appendLine(`[PermissionManager] 自动批准 → ${toolName}`)
+      return 'allow'
+    }
+
+    // 4. acceptEdits 模式：只允许文件编辑类工具，其他询问
+    if (this.settings.permissionMode === 'acceptEdits' && this.isEditTool(toolName)) {
+      this.outputChannel.appendLine(`[PermissionManager] acceptEdits → 允许 ${toolName}`)
+      return 'allow'
+    }
+
+    // 5. 发送到 WebView 内嵌审批（先通知 WebView 显示审批 UI）
+    this._onPermissionRequest.fire(request)
+
+    // 返回 Promise，等待用户在 WebView 中决策
+    return new Promise<PermissionDecision>((resolve) => {
+      this.pendingRequests.set(requestId, { request, resolve })
+      this.outputChannel.appendLine(`[PermissionManager] 等待用户决策: ${toolName} (${requestId})`)
+
+      // 如果 WebView 不可用，回退到 VSCode 弹窗
+      this.showVSCodePermissionDialog(request).then((decision) => {
+        // 只有还未决策时才使用弹窗结果
+        if (this.pendingRequests.has(requestId)) {
+          this.resolvePending(requestId, decision, false)
+        }
+      })
+    })
+  }
+
+  /**
+   * 由 WebView 调用 - 用户在内嵌 UI 中做出决策
+   */
+  resolveFromWebView(requestId: string, decision: PermissionDecision, remember: boolean): void {
+    this.resolvePending(requestId, decision, remember)
+  }
+
+  /**
+   * 清除会话级别的记忆（新对话时调用）
+   */
+  clearSessionMemory(): void {
+    this.sessionMemory.clear()
+    this.outputChannel.appendLine('[PermissionManager] 清除会话记忆')
+  }
+
+  /**
+   * 取消所有待决策的请求（停止生成时调用）
+   */
+  cancelAll(): void {
+    for (const [requestId, pending] of this.pendingRequests) {
+      this.outputChannel.appendLine(`[PermissionManager] 取消请求: ${requestId}`)
+      pending.resolve('deny')
+    }
+    this.pendingRequests.clear()
+  }
+
+  // ===== 私有方法 =====
+
+  /**
+   * 解析等待中的权限请求
+   */
+  private resolvePending(requestId: string, decision: PermissionDecision, remember: boolean): void {
+    const pending = this.pendingRequests.get(requestId)
+    if (!pending) return
+
+    this.outputChannel.appendLine(
+      `[PermissionManager] 决策: ${pending.request.toolName} → ${decision}${remember ? ' (记住)' : ''}`,
+    )
+
+    // 如果选择记住，写入会话记忆
+    if (remember) {
+      this.sessionMemory.set(pending.request.toolName, decision)
+    }
+
+    // 移除等待列表
+    this.pendingRequests.delete(requestId)
+    // 广播已解决事件（通知 WebView 更新 UI）
+    this._onPermissionResolved.fire({ requestId, decision })
+    // 解析 Promise
+    pending.resolve(decision)
+  }
+
+  /**
+   * 检查工具是否在自动批准列表中
+   */
+  private isAutoApproved(toolName: string): boolean {
+    return this.settings.autoApproveTools.some(
+      (name) => name.toLowerCase() === toolName.toLowerCase(),
+    )
+  }
+
+  /**
+   * 判断是否为文件编辑类工具（acceptEdits 模式使用）
+   */
+  private isEditTool(toolName: string): boolean {
+    const editTools = ['Write', 'Edit', 'FileWrite', 'FileEdit', 'NotebookEdit']
+    return editTools.some((t) => t.toLowerCase() === toolName.toLowerCase())
+  }
+
+  /**
+   * 显示 VSCode 信息弹窗进行权限审批（WebView 不可用时的回退）
+   */
+  private async showVSCodePermissionDialog(request: PermissionRequest): Promise<PermissionDecision> {
+    const { toolName, toolInput } = request
+
+    // 构建工具调用摘要
+    const summary = this.formatToolSummary(toolName, toolInput)
+
+    // 显示信息弹窗，提供 允许/拒绝 按钮
+    const choice = await vscode.window.showInformationMessage(
+      `Claude 想要使用工具 **${toolName}**\n${summary}`,
+      { modal: true },
+      '允许',
+      '拒绝',
+    )
+
+    return choice === '允许' ? 'allow' : 'deny'
+  }
+
+  /**
+   * 格式化工具调用摘要（用于弹窗显示）
+   */
+  private formatToolSummary(toolName: string, input: Record<string, unknown>): string {
+    // 针对常见工具提供友好的摘要格式
+    switch (toolName) {
+      case 'Bash':
+        return `命令：${String(input.command ?? '').slice(0, 100)}`
+      case 'Write':
+      case 'FileWrite':
+        return `文件：${String(input.file_path ?? input.path ?? '')}`
+      case 'Edit':
+      case 'FileEdit':
+        return `文件：${String(input.file_path ?? input.path ?? '')}`
+      case 'WebFetch':
+        return `URL：${String(input.url ?? '').slice(0, 80)}`
+      default: {
+        // 通用格式：显示前几个参数
+        const parts = Object.entries(input)
+          .slice(0, 3)
+          .map(([k, v]) => `${k}=${String(v).slice(0, 30)}`)
+          .join(', ')
+        return parts || '（无参数）'
+      }
+    }
+  }
+
+  /** 释放资源 */
+  dispose(): void {
+    // 取消所有待决策请求
+    this.cancelAll()
+    this._onPermissionRequest.dispose()
+    this._onPermissionResolved.dispose()
+  }
+}

--- a/ide/vscode/src/services/SessionManager.ts
+++ b/ide/vscode/src/services/SessionManager.ts
@@ -1,0 +1,290 @@
+// 会话管理服务 - 持久化和管理聊天会话
+import * as vscode from 'vscode'
+import * as path from 'path'
+import * as fs from 'fs'
+import type { Session, ChatMessage, ProviderType } from '../types'
+
+/** 会话存储文件名 */
+const SESSIONS_FILE = 'claude-code-sessions.json'
+
+/** 最大保留会话数量 */
+const MAX_SESSIONS = 50
+
+/** 会话存储结构 */
+interface SessionsStore {
+  version: number
+  sessions: Session[]
+  currentSessionId: string | null
+}
+
+/**
+ * 会话管理器
+ * 负责创建、切换、持久化聊天会话
+ */
+export class SessionManager {
+  // 当前活跃会话
+  private currentSession: Session | null = null
+  // 所有会话列表
+  private sessions: Session[] = []
+  // 存储目录（VSCode 扩展全局存储路径）
+  private storePath: string
+  // 输出日志
+  private outputChannel: vscode.OutputChannel
+  // 会话变化事件
+  private readonly _onSessionChange = new vscode.EventEmitter<Session | null>()
+  readonly onSessionChange = this._onSessionChange.event
+
+  constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel) {
+    // 使用 VSCode 的全局存储路径持久化会话
+    this.storePath = context.globalStorageUri.fsPath
+    this.outputChannel = outputChannel
+    // 确保存储目录存在
+    this.ensureStorageDir()
+    // 从磁盘加载会话
+    this.loadSessions()
+  }
+
+  // ===== 公开 API =====
+
+  /** 当前活跃会话 */
+  get current(): Session | null {
+    return this.currentSession
+  }
+
+  /** 所有会话列表（按更新时间倒序） */
+  get all(): Session[] {
+    return [...this.sessions].sort((a, b) => b.updatedAt - a.updatedAt)
+  }
+
+  /**
+   * 创建新会话
+   */
+  createSession(options: {
+    workingDirectory: string
+    model?: string
+    provider?: ProviderType
+  }): Session {
+    // 生成唯一会话 ID
+    const id = `session_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+    const now = Date.now()
+
+    // 构建新会话
+    const session: Session = {
+      id,
+      title: `对话 ${this.sessions.length + 1}`,
+      createdAt: now,
+      updatedAt: now,
+      messages: [],
+      workingDirectory: options.workingDirectory,
+      model: options.model,
+      provider: options.provider,
+      status: 'idle',
+      totalUsage: { input_tokens: 0, output_tokens: 0, cost_usd: 0 },
+    }
+
+    // 限制最大会话数，超出时删除最旧的
+    if (this.sessions.length >= MAX_SESSIONS) {
+      const sorted = [...this.sessions].sort((a, b) => a.updatedAt - b.updatedAt)
+      // 删除最旧的 10 个会话
+      const toRemove = sorted.slice(0, 10).map((s) => s.id)
+      this.sessions = this.sessions.filter((s) => !toRemove.includes(s.id))
+    }
+
+    // 追加到会话列表
+    this.sessions.push(session)
+    // 切换为当前会话
+    this.currentSession = session
+    // 持久化
+    this.saveSessions()
+    // 广播变化
+    this._onSessionChange.fire(session)
+
+    this.outputChannel.appendLine(`[SessionManager] 创建新会话: ${id}`)
+    return session
+  }
+
+  /**
+   * 切换到指定会话
+   */
+  switchSession(sessionId: string): Session | null {
+    // 查找目标会话
+    const session = this.sessions.find((s) => s.id === sessionId)
+    if (!session) {
+      this.outputChannel.appendLine(`[SessionManager] 会话不存在: ${sessionId}`)
+      return null
+    }
+    // 切换当前会话
+    this.currentSession = session
+    this._onSessionChange.fire(session)
+    this.outputChannel.appendLine(`[SessionManager] 切换到会话: ${sessionId}`)
+    return session
+  }
+
+  /**
+   * 删除指定会话
+   */
+  deleteSession(sessionId: string): void {
+    // 从列表中移除
+    this.sessions = this.sessions.filter((s) => s.id !== sessionId)
+    // 如果删除的是当前会话，切换到最新的会话
+    if (this.currentSession?.id === sessionId) {
+      this.currentSession = this.sessions.length > 0
+        ? [...this.sessions].sort((a, b) => b.updatedAt - a.updatedAt)[0]
+        : null
+      this._onSessionChange.fire(this.currentSession)
+    }
+    // 持久化
+    this.saveSessions()
+    this.outputChannel.appendLine(`[SessionManager] 删除会话: ${sessionId}`)
+  }
+
+  /**
+   * 追加消息到当前会话
+   */
+  appendMessage(message: ChatMessage): void {
+    if (!this.currentSession) return
+    // 追加消息
+    this.currentSession.messages.push(message)
+    // 更新时间戳
+    this.currentSession.updatedAt = Date.now()
+    // 根据第一条用户消息自动命名会话
+    if (this.currentSession.title.startsWith('对话 ') && message.role === 'user') {
+      this.currentSession.title = this.generateTitle(message.content)
+    }
+    // 持久化（防抖保存）
+    this.debouncedSave()
+  }
+
+  /**
+   * 更新消息内容（流式输出增量更新）
+   */
+  updateMessage(messageId: string, delta: Partial<ChatMessage>): void {
+    if (!this.currentSession) return
+    // 找到目标消息
+    const msg = this.currentSession.messages.find((m) => m.id === messageId)
+    if (!msg) return
+    // 合并更新
+    Object.assign(msg, delta)
+    // 更新会话时间戳
+    this.currentSession.updatedAt = Date.now()
+    // 防抖保存
+    this.debouncedSave()
+  }
+
+  /**
+   * 更新会话的 CLI session ID（从 init 事件获取）
+   */
+  setCliSessionId(cliSessionId: string): void {
+    if (!this.currentSession) return
+    this.currentSession.cliSessionId = cliSessionId
+  }
+
+  /**
+   * 更新会话 token 用量统计
+   */
+  updateUsage(inputTokens: number, outputTokens: number, costUsd: number): void {
+    if (!this.currentSession?.totalUsage) return
+    // 累加 token 用量
+    this.currentSession.totalUsage.input_tokens += inputTokens
+    this.currentSession.totalUsage.output_tokens += outputTokens
+    this.currentSession.totalUsage.cost_usd += costUsd
+    this.debouncedSave()
+  }
+
+  /**
+   * 更新会话状态
+   */
+  updateStatus(status: Session['status'], error?: string): void {
+    if (!this.currentSession) return
+    this.currentSession.status = status
+    if (error !== undefined) {
+      // 如果有错误，追加一条系统错误消息
+      const errMsg: ChatMessage = {
+        id: `err_${Date.now()}`,
+        role: 'system',
+        content: `错误：${error}`,
+        timestamp: Date.now(),
+      }
+      this.currentSession.messages.push(errMsg)
+    }
+    this.debouncedSave()
+  }
+
+  // ===== 私有方法 =====
+
+  /** 确保存储目录存在 */
+  private ensureStorageDir(): void {
+    if (!fs.existsSync(this.storePath)) {
+      fs.mkdirSync(this.storePath, { recursive: true })
+    }
+  }
+
+  /** 会话文件路径 */
+  private get sessionsFilePath(): string {
+    return path.join(this.storePath, SESSIONS_FILE)
+  }
+
+  /** 从磁盘加载会话 */
+  private loadSessions(): void {
+    try {
+      if (!fs.existsSync(this.sessionsFilePath)) {
+        this.outputChannel.appendLine('[SessionManager] 无历史会话文件，初始化为空')
+        return
+      }
+      const raw = fs.readFileSync(this.sessionsFilePath, 'utf-8')
+      const store: SessionsStore = JSON.parse(raw)
+      this.sessions = store.sessions || []
+      // 恢复当前会话
+      if (store.currentSessionId) {
+        this.currentSession = this.sessions.find((s) => s.id === store.currentSessionId) ?? null
+      }
+      this.outputChannel.appendLine(`[SessionManager] 加载 ${this.sessions.length} 个历史会话`)
+    } catch (err) {
+      this.outputChannel.appendLine(`[SessionManager] 加载会话失败: ${err}`)
+      this.sessions = []
+    }
+  }
+
+  /** 保存会话到磁盘 */
+  private saveSessions(): void {
+    try {
+      const store: SessionsStore = {
+        version: 1,
+        sessions: this.sessions,
+        currentSessionId: this.currentSession?.id ?? null,
+      }
+      fs.writeFileSync(this.sessionsFilePath, JSON.stringify(store, null, 2), 'utf-8')
+    } catch (err) {
+      this.outputChannel.appendLine(`[SessionManager] 保存会话失败: ${err}`)
+    }
+  }
+
+  /** 防抖保存（避免高频写磁盘） */
+  private saveTimer: ReturnType<typeof setTimeout> | null = null
+  private debouncedSave(): void {
+    if (this.saveTimer) clearTimeout(this.saveTimer)
+    this.saveTimer = setTimeout(() => {
+      this.saveSessions()
+      this.saveTimer = null
+    }, 1000)
+  }
+
+  /**
+   * 根据用户消息内容自动生成会话标题
+   * 截取前 30 个字符
+   */
+  private generateTitle(content: string): string {
+    const clean = content.replace(/\n/g, ' ').trim()
+    return clean.length > 30 ? clean.slice(0, 30) + '…' : clean
+  }
+
+  /** 释放资源 */
+  dispose(): void {
+    // 立即保存待保存的会话
+    if (this.saveTimer) {
+      clearTimeout(this.saveTimer)
+      this.saveSessions()
+    }
+    this._onSessionChange.dispose()
+  }
+}

--- a/ide/vscode/src/types/index.ts
+++ b/ide/vscode/src/types/index.ts
@@ -1,0 +1,283 @@
+// VSCode 插件类型定义 - 基于 csc 项目的核心类型
+// 覆盖：消息类型、工具类型、会话类型、权限类型、Provider 类型
+
+// ===== 消息类型 =====
+
+/** 消息角色 */
+export type MessageRole = 'user' | 'assistant' | 'system'
+
+/** 内容块类型 */
+export type ContentBlockType = 'text' | 'tool_use' | 'tool_result' | 'thinking' | 'image'
+
+/** 文本内容块 */
+export interface TextContent {
+  type: 'text'
+  text: string
+}
+
+/** 工具调用内容块 */
+export interface ToolUseContent {
+  type: 'tool_use'
+  id: string
+  name: string
+  input: Record<string, unknown>
+}
+
+/** 工具结果内容块 */
+export interface ToolResultContent {
+  type: 'tool_result'
+  tool_use_id: string
+  content: string | Array<{ type: string; text?: string }>
+  is_error?: boolean
+}
+
+/** 思考内容块 */
+export interface ThinkingContent {
+  type: 'thinking'
+  thinking: string
+}
+
+/** 内容块联合类型 */
+export type ContentBlock = TextContent | ToolUseContent | ToolResultContent | ThinkingContent
+
+/** API 消息（发给 Claude 的标准格式） */
+export interface ApiMessage {
+  role: MessageRole
+  content: string | ContentBlock[]
+}
+
+// ===== stream-json 协议事件 =====
+
+/** 系统初始化事件 */
+export interface StreamSystemEvent {
+  type: 'system'
+  subtype: 'init'
+  session_id: string
+  tools?: Array<{ name: string; description: string }>
+  mcp_servers?: Array<{ name: string; status: string }>
+  model?: string
+  cwd?: string
+  permissionMode?: string
+}
+
+/** 助手消息事件 */
+export interface StreamAssistantEvent {
+  type: 'assistant'
+  message: {
+    id: string
+    type: 'message'
+    role: 'assistant'
+    content: ContentBlock[]
+    model: string
+    stop_reason: string | null
+    usage?: {
+      input_tokens: number
+      output_tokens: number
+      cache_creation_input_tokens?: number
+      cache_read_input_tokens?: number
+    }
+  }
+}
+
+/** 用户消息事件（工具结果回传） */
+export interface StreamUserEvent {
+  type: 'user'
+  message: {
+    role: 'user'
+    content: ContentBlock[]
+  }
+}
+
+/** 结果事件（对话完成） */
+export interface StreamResultEvent {
+  type: 'result'
+  subtype: 'success' | 'error_max_turns' | 'error_during_execution'
+  session_id: string
+  result?: string
+  cost_usd?: number
+  duration_ms?: number
+  num_turns?: number
+  total_cost?: number
+  usage?: {
+    input_tokens: number
+    output_tokens: number
+    cache_creation_input_tokens?: number
+    cache_read_input_tokens?: number
+  }
+  is_error?: boolean
+  error?: string
+}
+
+/** 权限请求事件 */
+export interface StreamPermissionEvent {
+  type: 'permission_request'
+  tool_name: string
+  tool_input: Record<string, unknown>
+  request_id: string
+  description?: string
+}
+
+/** 所有 stream-json 输出事件 */
+export type StreamEvent =
+  | StreamSystemEvent
+  | StreamAssistantEvent
+  | StreamUserEvent
+  | StreamResultEvent
+  | StreamPermissionEvent
+
+// ===== 输入消息格式 =====
+
+/** 向 CLI 发送用户消息 */
+export interface InputUserMessage {
+  type: 'user'
+  message: string | ContentBlock[]
+}
+
+/** 权限决策消息 */
+export interface InputPermissionResponse {
+  type: 'permission_response'
+  request_id: string
+  decision: 'allow' | 'deny'
+  remember?: boolean
+}
+
+/** 所有 stream-json 输入消息 */
+export type InputMessage = InputUserMessage | InputPermissionResponse
+
+// ===== 插件内部消息类型（WebView <-> Extension） =====
+
+/** 聊天消息（插件 UI 内部） */
+export interface ChatMessage {
+  id: string
+  role: MessageRole
+  content: string
+  timestamp: number
+  // 工具调用信息
+  toolCalls?: ToolCallInfo[]
+  // 是否正在流式输出
+  streaming?: boolean
+  // token 用量
+  usage?: {
+    input_tokens: number
+    output_tokens: number
+    cost_usd?: number
+  }
+  // 思考过程
+  thinking?: string
+}
+
+/** 工具调用信息（插件 UI 显示用） */
+export interface ToolCallInfo {
+  id: string
+  name: string
+  input: Record<string, unknown>
+  result?: string
+  isError?: boolean
+  status: 'pending' | 'approved' | 'denied' | 'completed' | 'error'
+  // 权限请求 ID（如需人工审批）
+  permissionRequestId?: string
+}
+
+/** 权限请求（传给 WebView 显示） */
+export interface PermissionRequest {
+  requestId: string
+  toolName: string
+  toolInput: Record<string, unknown>
+  description?: string
+  timestamp: number
+}
+
+// ===== 会话类型 =====
+
+/** 会话状态 */
+export type SessionStatus = 'idle' | 'connecting' | 'running' | 'waiting_permission' | 'error' | 'stopped'
+
+/** 会话信息 */
+export interface Session {
+  id: string
+  title: string
+  createdAt: number
+  updatedAt: number
+  messages: ChatMessage[]
+  workingDirectory: string
+  model?: string
+  provider?: ProviderType
+  status: SessionStatus
+  // CLI 会话 ID（从 stream-json system init 事件获取）
+  cliSessionId?: string
+  // 累计 token 用量
+  totalUsage?: {
+    input_tokens: number
+    output_tokens: number
+    cost_usd: number
+  }
+}
+
+// ===== Provider 类型 =====
+
+/** AI 提供商 */
+export type ProviderType = 'anthropic' | 'openai' | 'gemini' | 'bedrock' | 'vertex' | 'grok'
+
+/** Provider 配置 */
+export interface ProviderConfig {
+  provider: ProviderType
+  apiKey?: string
+  baseUrl?: string
+  model?: string
+  // 额外环境变量（如 AWS 凭证等）
+  extraEnv?: Record<string, string>
+}
+
+// ===== 权限类型 =====
+
+/** 权限模式 */
+export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions'
+
+// ===== VSCode 插件设置 =====
+
+/** 插件配置 */
+export interface ExtensionSettings {
+  // CLI 路径
+  cliPath: string
+  // 运行时
+  runtime: 'auto' | 'node' | 'bun'
+  // Provider 设置
+  provider: ProviderType
+  model: string
+  apiKey: string
+  openaiBaseUrl: string
+  // 权限设置
+  permissionMode: PermissionMode
+  autoApproveTools: string[]
+  // 对话设置
+  workingDirectory: string
+  maxTurns: number
+  enableStreaming: boolean
+  showThinking: boolean
+  systemPrompt: string
+}
+
+// ===== WebView 消息协议（Extension <-> WebView） =====
+
+/** WebView 收到的消息类型 */
+export type WebViewMessage =
+  | { type: 'init'; session: Session; settings: Partial<ExtensionSettings> }
+  | { type: 'message_append'; message: ChatMessage }
+  | { type: 'message_update'; messageId: string; delta: Partial<ChatMessage> }
+  | { type: 'session_status'; status: SessionStatus; error?: string }
+  | { type: 'permission_request'; request: PermissionRequest }
+  | { type: 'permission_resolved'; requestId: string; decision: 'allow' | 'deny' }
+  | { type: 'tool_update'; messageId: string; toolCallId: string; update: Partial<ToolCallInfo> }
+  | { type: 'sessions_list'; sessions: Array<Pick<Session, 'id' | 'title' | 'createdAt' | 'updatedAt'>> }
+  | { type: 'thinking_update'; messageId: string; thinking: string }
+
+/** Extension 收到的 WebView 消息类型 */
+export type ExtensionMessage =
+  | { type: 'send_message'; content: string }
+  | { type: 'permission_decision'; requestId: string; decision: 'allow' | 'deny'; remember?: boolean }
+  | { type: 'new_chat' }
+  | { type: 'load_session'; sessionId: string }
+  | { type: 'delete_session'; sessionId: string }
+  | { type: 'stop_generation' }
+  | { type: 'get_sessions' }
+  | { type: 'ready' }

--- a/ide/vscode/src/webview/main.ts
+++ b/ide/vscode/src/webview/main.ts
@@ -1,0 +1,840 @@
+// WebView 主脚本 - 聊天界面完整实现
+// 运行在 VSCode WebView 沙箱环境中，通过 postMessage 与 Extension 通信
+
+import type {
+  WebViewMessage,
+  ExtensionMessage,
+  ChatMessage,
+  PermissionRequest,
+  Session,
+  ToolCallInfo,
+} from '../types'
+
+// VSCode WebView API（由 VSCode 注入）
+declare const acquireVsCodeApi: () => {
+  postMessage(msg: ExtensionMessage): void
+  getState(): unknown
+  setState(state: unknown): void
+}
+
+// ===== 初始化 VSCode API =====
+const vscode = acquireVsCodeApi()
+
+// ===== 状态 =====
+let currentSession: Session | null = null
+let isRunning = false
+let showThinking = false
+let sessionsVisible = false
+
+// ===== DOM 引用 =====
+let messagesContainer: HTMLElement
+let inputTextarea: HTMLTextAreaElement
+let sendBtn: HTMLButtonElement
+let sessionTitle: HTMLElement
+let statusBadge: HTMLElement
+let sessionsPanel: HTMLElement
+let sessionsList: HTMLElement
+
+// ===== 工具图标映射 =====
+const TOOL_ICONS: Record<string, string> = {
+  Bash: '⚡',
+  BashTool: '⚡',
+  FileReadTool: '📖',
+  Read: '📖',
+  FileWriteTool: '✏️',
+  Write: '✏️',
+  FileEditTool: '✏️',
+  Edit: '✏️',
+  GlobTool: '🔍',
+  Glob: '🔍',
+  GrepTool: '🔎',
+  Grep: '🔎',
+  WebFetchTool: '🌐',
+  WebFetch: '🌐',
+  WebSearchTool: '🔍',
+  WebSearch: '🔍',
+  AgentTool: '🤖',
+  MCPTool: '🔌',
+  NotebookEditTool: '📓',
+  default: '🔧',
+}
+
+// ===== 入口 =====
+document.addEventListener('DOMContentLoaded', () => {
+  // 初始化 DOM 引用
+  initDOM()
+  // 绑定事件
+  bindEvents()
+  // 通知 Extension WebView 已就绪
+  postMessage({ type: 'ready' })
+})
+
+// ===== DOM 初始化 =====
+function initDOM(): void {
+  // 创建完整 UI 结构
+  const app = document.getElementById('app')!
+  app.innerHTML = `
+    <!-- 顶部工具栏 -->
+    <div class="toolbar" id="toolbar">
+      <div class="toolbar-left">
+        <span class="session-title" id="session-title">Claude Code</span>
+        <span class="status-badge" id="status-badge">空闲</span>
+      </div>
+      <div class="toolbar-right">
+        <button class="icon-btn" id="btn-history" title="查看历史对话">🕐</button>
+        <button class="icon-btn" id="btn-new-chat" title="新建对话">＋</button>
+        <button class="icon-btn" id="btn-clear" title="清除当前对话">🗑</button>
+      </div>
+    </div>
+
+    <!-- 消息列表 -->
+    <div class="messages-container" id="messages-container">
+      <!-- 欢迎屏幕（无消息时显示） -->
+      <div class="welcome-screen" id="welcome-screen">
+        <div class="welcome-icon">🤖</div>
+        <div class="welcome-title">Claude Code</div>
+        <div class="welcome-desc">AI 编程助手，基于 Claude 模型</div>
+        <div class="welcome-tips">
+          <button class="tip-item" onclick="sendQuickPrompt('解释当前工作区的项目结构')">
+            📁 分析项目结构
+          </button>
+          <button class="tip-item" onclick="sendQuickPrompt('查看当前 git 状态和最近的修改')">
+            🔀 查看 Git 状态
+          </button>
+          <button class="tip-item" onclick="sendQuickPrompt('检查项目中是否有潜在的安全问题')">
+            🔒 安全检查
+          </button>
+          <button class="tip-item" onclick="sendQuickPrompt('帮我写单元测试')">
+            🧪 生成测试
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- 输入区域 -->
+    <div class="input-area" id="input-area">
+      <div class="input-wrapper">
+        <textarea
+          class="message-input"
+          id="message-input"
+          placeholder="输入消息... (Enter 发送，Shift+Enter 换行)"
+          rows="1"
+        ></textarea>
+        <button class="send-btn" id="send-btn" title="发送">▶</button>
+      </div>
+      <div class="input-hint" id="input-hint">Enter 发送 · Shift+Enter 换行</div>
+    </div>
+
+    <!-- 会话历史面板（覆盖层） -->
+    <div class="sessions-panel" id="sessions-panel" style="display:none">
+      <div class="sessions-panel-header">
+        <span>历史对话</span>
+        <button class="icon-btn" id="btn-close-sessions" title="关闭">✕</button>
+      </div>
+      <div class="sessions-list" id="sessions-list"></div>
+      <div style="padding:8px;border-top:1px solid var(--claude-border)">
+        <button class="btn btn-secondary" style="width:100%" id="btn-new-in-panel">＋ 新建对话</button>
+      </div>
+    </div>
+  `
+
+  // 获取 DOM 引用
+  messagesContainer = document.getElementById('messages-container')!
+  inputTextarea = document.getElementById('message-input') as HTMLTextAreaElement
+  sendBtn = document.getElementById('send-btn') as HTMLButtonElement
+  sessionTitle = document.getElementById('session-title')!
+  statusBadge = document.getElementById('status-badge')!
+  sessionsPanel = document.getElementById('sessions-panel')!
+  sessionsList = document.getElementById('sessions-list')!
+}
+
+// 快速提示（欢迎屏按钮调用）
+;(window as unknown as Record<string, unknown>)['sendQuickPrompt'] = (text: string) => {
+  inputTextarea.value = text
+  sendMessage()
+}
+
+// ===== 事件绑定 =====
+function bindEvents(): void {
+  // 发送按钮
+  sendBtn.addEventListener('click', () => {
+    if (isRunning) {
+      // 运行中时点击发送按钮变为停止按钮
+      postMessage({ type: 'stop_generation' })
+    } else {
+      sendMessage()
+    }
+  })
+
+  // 输入框快捷键
+  inputTextarea.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      // Enter 发送消息
+      e.preventDefault()
+      if (!isRunning) sendMessage()
+    }
+  })
+
+  // 自动调整输入框高度
+  inputTextarea.addEventListener('input', () => {
+    autoResizeTextarea()
+    updateSendButton()
+  })
+
+  // 工具栏按钮
+  document.getElementById('btn-new-chat')!.addEventListener('click', () => {
+    postMessage({ type: 'new_chat' })
+  })
+
+  document.getElementById('btn-clear')!.addEventListener('click', () => {
+    if (confirm('确认清除当前对话的所有消息？')) {
+      clearMessages()
+      postMessage({ type: 'new_chat' })
+    }
+  })
+
+  document.getElementById('btn-history')!.addEventListener('click', () => {
+    toggleSessionsPanel()
+  })
+
+  document.getElementById('btn-close-sessions')!.addEventListener('click', () => {
+    hideSessionsPanel()
+  })
+
+  document.getElementById('btn-new-in-panel')!.addEventListener('click', () => {
+    hideSessionsPanel()
+    postMessage({ type: 'new_chat' })
+  })
+
+  // 监听来自 Extension 的消息
+  window.addEventListener('message', (event: MessageEvent) => {
+    handleExtensionMessage(event.data as WebViewMessage)
+  })
+}
+
+// ===== 发送消息 =====
+function sendMessage(): void {
+  const content = inputTextarea.value.trim()
+  if (!content) return
+
+  // 清空输入框
+  inputTextarea.value = ''
+  autoResizeTextarea()
+  updateSendButton()
+
+  // 发送到 Extension
+  postMessage({ type: 'send_message', content })
+}
+
+// ===== 处理 Extension 消息 =====
+function handleExtensionMessage(msg: WebViewMessage): void {
+  switch (msg.type) {
+    case 'init':
+      // 初始化会话状态
+      currentSession = msg.session
+      showThinking = msg.settings.showThinking ?? false
+      updateSessionHeader(msg.session)
+      renderAllMessages(msg.session.messages)
+      break
+
+    case 'message_append':
+      // 追加新消息
+      appendMessage(msg.message)
+      break
+
+    case 'message_update':
+      // 更新消息内容（流式更新）
+      updateMessage(msg.messageId, msg.delta)
+      break
+
+    case 'session_status':
+      // 更新状态
+      updateStatus(msg.status, msg.error)
+      break
+
+    case 'permission_request':
+      // 显示权限审批卡片
+      showPermissionCard(msg.request)
+      break
+
+    case 'permission_resolved':
+      // 移除权限审批卡片
+      removePermissionCard(msg.requestId, msg.decision)
+      break
+
+    case 'tool_update':
+      // 更新工具调用状态
+      updateToolCall(msg.messageId, msg.toolCallId, msg.update)
+      break
+
+    case 'thinking_update':
+      // 更新思考内容
+      updateThinking(msg.messageId, msg.thinking)
+      break
+
+    case 'sessions_list':
+      // 渲染会话列表
+      renderSessionsList(msg.sessions)
+      break
+  }
+}
+
+// ===== 渲染所有消息 =====
+function renderAllMessages(messages: ChatMessage[]): void {
+  // 清空消息区（保留欢迎屏）
+  const welcomeScreen = document.getElementById('welcome-screen')
+  messagesContainer.innerHTML = ''
+  if (welcomeScreen) messagesContainer.appendChild(welcomeScreen)
+
+  if (messages.length === 0) {
+    showWelcome(true)
+    return
+  }
+
+  showWelcome(false)
+  for (const msg of messages) {
+    renderMessage(msg)
+  }
+  scrollToBottom()
+}
+
+// ===== 追加消息 =====
+function appendMessage(msg: ChatMessage): void {
+  showWelcome(false)
+  renderMessage(msg)
+  scrollToBottom()
+}
+
+// ===== 渲染单条消息 =====
+function renderMessage(msg: ChatMessage): void {
+  const el = createMessageElement(msg)
+  messagesContainer.appendChild(el)
+}
+
+// ===== 创建消息元素 =====
+function createMessageElement(msg: ChatMessage): HTMLElement {
+  const wrapper = document.createElement('div')
+  wrapper.className = `message ${msg.role}`
+  wrapper.dataset.messageId = msg.id
+
+  // 消息头部（显示角色和时间）
+  if (msg.role !== 'system') {
+    const header = document.createElement('div')
+    header.className = 'message-header'
+    header.innerHTML = `
+      <span>${msg.role === 'user' ? '你' : '🤖 Claude'}</span>
+      <span>${formatTime(msg.timestamp)}</span>
+    `
+    wrapper.appendChild(header)
+  }
+
+  // 气泡
+  const bubble = document.createElement('div')
+  bubble.className = `message-bubble${msg.streaming ? ' streaming' : ''}`
+  bubble.dataset.bubbleId = msg.id
+
+  // 思考内容（如果有）
+  if (msg.thinking && showThinking) {
+    bubble.appendChild(createThinkingBlock(msg.thinking))
+  }
+
+  // 消息正文（Markdown 渲染）
+  const contentEl = document.createElement('div')
+  contentEl.className = 'message-content'
+  contentEl.innerHTML = renderMarkdown(msg.content)
+  bubble.appendChild(contentEl)
+
+  // 工具调用区
+  if (msg.toolCalls && msg.toolCalls.length > 0) {
+    const toolCallsEl = document.createElement('div')
+    toolCallsEl.className = 'tool-calls'
+    for (const tc of msg.toolCalls) {
+      toolCallsEl.appendChild(createToolCallElement(tc))
+    }
+    bubble.appendChild(toolCallsEl)
+  }
+
+  // token 用量
+  if (msg.usage && (msg.usage.input_tokens > 0 || msg.usage.output_tokens > 0)) {
+    const usage = document.createElement('div')
+    usage.style.cssText = 'font-size:10px;opacity:0.4;text-align:right;margin-top:4px'
+    usage.textContent = `↑${msg.usage.input_tokens} ↓${msg.usage.output_tokens} tokens`
+    bubble.appendChild(usage)
+  }
+
+  wrapper.appendChild(bubble)
+  return wrapper
+}
+
+// ===== 更新消息内容 =====
+function updateMessage(messageId: string, delta: Partial<ChatMessage>): void {
+  const bubble = document.querySelector(`[data-bubble-id="${messageId}"]`) as HTMLElement
+  if (!bubble) {
+    // 消息不存在，可能需要新建
+    if (currentSession) {
+      const msg = currentSession.messages.find((m) => m.id === messageId)
+      if (msg) {
+        Object.assign(msg, delta)
+        appendMessage(msg)
+      }
+    }
+    return
+  }
+
+  // 更新流式动画
+  if (delta.streaming !== undefined) {
+    bubble.classList.toggle('streaming', delta.streaming)
+  }
+
+  // 更新文本内容
+  if (delta.content !== undefined) {
+    const contentEl = bubble.querySelector('.message-content')
+    if (contentEl) {
+      contentEl.innerHTML = renderMarkdown(delta.content)
+    }
+  }
+
+  // 更新工具调用
+  if (delta.toolCalls) {
+    let toolCallsEl = bubble.querySelector('.tool-calls') as HTMLElement
+    if (!toolCallsEl) {
+      toolCallsEl = document.createElement('div')
+      toolCallsEl.className = 'tool-calls'
+      bubble.appendChild(toolCallsEl)
+    }
+    // 更新或新增工具调用项
+    for (const tc of delta.toolCalls) {
+      const existing = toolCallsEl.querySelector(`[data-tool-id="${tc.id}"]`)
+      if (existing) {
+        existing.replaceWith(createToolCallElement(tc))
+      } else {
+        toolCallsEl.appendChild(createToolCallElement(tc))
+      }
+    }
+  }
+
+  scrollToBottom()
+}
+
+// ===== 更新工具调用状态 =====
+function updateToolCall(messageId: string, toolCallId: string, update: Partial<ToolCallInfo>): void {
+  const toolEl = document.querySelector(
+    `[data-message-id="${messageId}"] [data-tool-id="${toolCallId}"]`,
+  ) as HTMLElement
+  if (!toolEl) return
+
+  // 更新状态徽章
+  if (update.status) {
+    const statusEl = toolEl.querySelector('.tool-call-status')
+    if (statusEl) {
+      statusEl.className = `tool-call-status ${update.status}`
+      statusEl.textContent = getStatusText(update.status)
+    }
+  }
+
+  // 更新结果
+  if (update.result !== undefined) {
+    let resultEl = toolEl.querySelector('.tool-call-result') as HTMLElement
+    if (!resultEl) {
+      resultEl = document.createElement('div')
+      resultEl.className = `tool-call-result${update.isError ? ' error' : ''}`
+      toolEl.appendChild(resultEl)
+    }
+    resultEl.textContent = update.result.slice(0, 500)
+  }
+}
+
+// ===== 更新思考内容 =====
+function updateThinking(messageId: string, thinking: string): void {
+  if (!showThinking) return
+  const bubble = document.querySelector(`[data-bubble-id="${messageId}"]`)
+  if (!bubble) return
+
+  let thinkingEl = bubble.querySelector('.thinking-block') as HTMLElement
+  if (!thinkingEl) {
+    thinkingEl = createThinkingBlock(thinking)
+    bubble.insertBefore(thinkingEl, bubble.firstChild)
+  } else {
+    const contentEl = thinkingEl.querySelector('.thinking-content')
+    if (contentEl) contentEl.textContent = thinking
+  }
+}
+
+// ===== 工具调用元素 =====
+function createToolCallElement(tc: ToolCallInfo): HTMLElement {
+  const el = document.createElement('div')
+  el.className = 'tool-call'
+  el.dataset.toolId = tc.id
+
+  const icon = TOOL_ICONS[tc.name] ?? TOOL_ICONS.default
+  const inputStr = JSON.stringify(tc.input, null, 2)
+
+  el.innerHTML = `
+    <div class="tool-call-header" onclick="toggleToolCall(this)">
+      <span class="tool-call-icon">${icon}</span>
+      <span class="tool-call-name">${escapeHtml(tc.name)}</span>
+      <span class="tool-call-status ${tc.status}">${getStatusText(tc.status)}</span>
+    </div>
+    <div class="tool-call-body">
+      <pre style="font-size:11px;color:var(--claude-fg)">${escapeHtml(inputStr)}</pre>
+    </div>
+    ${tc.result ? `<div class="tool-call-result${tc.isError ? ' error' : ''}">${escapeHtml(tc.result.slice(0, 500))}</div>` : ''}
+  `
+  return el
+}
+
+// 切换工具调用展开
+;(window as unknown as Record<string, unknown>)['toggleToolCall'] = (header: HTMLElement) => {
+  header.closest('.tool-call')?.classList.toggle('expanded')
+}
+
+// ===== 思考内容块 =====
+function createThinkingBlock(thinking: string): HTMLElement {
+  const el = document.createElement('div')
+  el.className = 'thinking-block'
+  el.innerHTML = `
+    <div class="thinking-header" onclick="this.closest('.thinking-block').classList.toggle('expanded')">
+      <span>💭</span>
+      <span>思考过程</span>
+    </div>
+    <div class="thinking-content">${escapeHtml(thinking)}</div>
+  `
+  return el
+}
+
+// ===== 权限审批卡片 =====
+function showPermissionCard(request: PermissionRequest): void {
+  const card = document.createElement('div')
+  card.className = 'permission-card'
+  card.id = `permission-${request.requestId}`
+
+  const inputStr = formatPermissionInput(request.toolName, request.toolInput)
+
+  card.innerHTML = `
+    <div class="permission-header">
+      <span>⚠️</span>
+      <span>工具权限请求</span>
+    </div>
+    <div class="permission-body">
+      <div class="permission-tool-name">${escapeHtml(request.toolName)}</div>
+      ${request.description ? `<div style="font-size:12px;margin-bottom:8px;opacity:0.8">${escapeHtml(request.description)}</div>` : ''}
+      <div class="permission-input">${escapeHtml(inputStr)}</div>
+      <div class="permission-actions">
+        <button class="btn btn-primary" onclick="resolvePermission('${request.requestId}', 'allow')">
+          ✓ 允许
+        </button>
+        <button class="btn btn-danger" onclick="resolvePermission('${request.requestId}', 'deny')">
+          ✗ 拒绝
+        </button>
+        <label class="permission-remember">
+          <input type="checkbox" id="remember-${request.requestId}" />
+          记住此决策
+        </label>
+      </div>
+    </div>
+  `
+
+  messagesContainer.appendChild(card)
+  scrollToBottom()
+}
+
+// 解析权限（WebView 按钮调用）
+;(window as unknown as Record<string, unknown>)['resolvePermission'] = (
+  requestId: string,
+  decision: 'allow' | 'deny',
+) => {
+  const rememberEl = document.getElementById(`remember-${requestId}`) as HTMLInputElement
+  const remember = rememberEl?.checked ?? false
+
+  postMessage({ type: 'permission_decision', requestId, decision, remember })
+}
+
+function removePermissionCard(requestId: string, decision: 'allow' | 'deny'): void {
+  const card = document.getElementById(`permission-${requestId}`)
+  if (!card) return
+  // 显示决策结果后移除
+  card.style.opacity = '0.6'
+  card.style.transition = 'opacity 0.3s'
+  const body = card.querySelector('.permission-body')
+  if (body) {
+    body.innerHTML = `<div style="padding:8px;font-size:12px;color:${decision === 'allow' ? 'var(--claude-success)' : 'var(--claude-error)'}">
+      ${decision === 'allow' ? '✓ 已允许' : '✗ 已拒绝'}
+    </div>`
+  }
+  setTimeout(() => card.remove(), 1000)
+}
+
+// ===== 状态更新 =====
+function updateStatus(status: string, error?: string): void {
+  isRunning = status === 'running' || status === 'connecting' || status === 'waiting_permission'
+
+  // 更新状态徽章
+  statusBadge.className = 'status-badge'
+  switch (status) {
+    case 'running':
+    case 'connecting':
+      statusBadge.className += ' running'
+      statusBadge.textContent = status === 'connecting' ? '🔄 连接中' : '⚡ 生成中'
+      break
+    case 'waiting_permission':
+      statusBadge.className += ' waiting'
+      statusBadge.textContent = '⚠️ 等待授权'
+      break
+    case 'error':
+      statusBadge.className += ' error'
+      statusBadge.textContent = '❌ 错误'
+      if (error) {
+        appendErrorMessage(error)
+      }
+      break
+    default:
+      statusBadge.textContent = '空闲'
+  }
+
+  // 更新发送按钮样式
+  updateSendButton()
+}
+
+function appendErrorMessage(error: string): void {
+  const errEl = document.createElement('div')
+  errEl.className = 'message system'
+  errEl.innerHTML = `<div class="message-bubble" style="color:var(--claude-error)">⚠️ ${escapeHtml(error)}</div>`
+  messagesContainer.appendChild(errEl)
+  scrollToBottom()
+}
+
+// ===== 会话头部更新 =====
+function updateSessionHeader(session: Session): void {
+  sessionTitle.textContent = session.title || 'Claude Code'
+  sessionTitle.title = `工作目录：${session.workingDirectory}`
+}
+
+// ===== 会话历史面板 =====
+function toggleSessionsPanel(): void {
+  if (sessionsVisible) {
+    hideSessionsPanel()
+  } else {
+    sessionsPanel.style.display = 'flex'
+    sessionsVisible = true
+    postMessage({ type: 'get_sessions' })
+  }
+}
+
+function hideSessionsPanel(): void {
+  sessionsPanel.style.display = 'none'
+  sessionsVisible = false
+}
+
+function renderSessionsList(
+  sessions: Array<Pick<Session, 'id' | 'title' | 'createdAt' | 'updatedAt'>>,
+): void {
+  if (sessions.length === 0) {
+    sessionsList.innerHTML = '<div class="empty-sessions">暂无历史对话</div>'
+    return
+  }
+
+  sessionsList.innerHTML = ''
+  for (const s of sessions) {
+    const item = document.createElement('div')
+    const isActive = currentSession?.id === s.id
+    item.className = `session-item${isActive ? ' active' : ''}`
+    item.innerHTML = `
+      <div class="session-item-content" onclick="loadSession('${s.id}')">
+        <div class="session-item-title">${escapeHtml(s.title)}</div>
+        <div class="session-item-meta">${formatTime(s.updatedAt)}</div>
+      </div>
+      <button class="session-delete-btn" onclick="deleteSession(event, '${s.id}')" title="删除">✕</button>
+    `
+    sessionsList.appendChild(item)
+  }
+}
+
+;(window as unknown as Record<string, unknown>)['loadSession'] = (sessionId: string) => {
+  postMessage({ type: 'load_session', sessionId })
+  hideSessionsPanel()
+}
+
+;(window as unknown as Record<string, unknown>)['deleteSession'] = (
+  event: MouseEvent,
+  sessionId: string,
+) => {
+  event.stopPropagation()
+  if (confirm('确认删除此对话？')) {
+    postMessage({ type: 'delete_session', sessionId })
+  }
+}
+
+// ===== 清空消息 =====
+function clearMessages(): void {
+  const welcomeScreen = document.getElementById('welcome-screen')
+  messagesContainer.innerHTML = ''
+  if (welcomeScreen) messagesContainer.appendChild(welcomeScreen)
+  showWelcome(true)
+}
+
+// ===== 欢迎屏控制 =====
+function showWelcome(show: boolean): void {
+  const ws = document.getElementById('welcome-screen')
+  if (ws) ws.style.display = show ? 'flex' : 'none'
+}
+
+// ===== 辅助函数 =====
+
+/** 发消息给 Extension */
+function postMessage(msg: ExtensionMessage): void {
+  vscode.postMessage(msg)
+}
+
+/** 自动调整输入框高度 */
+function autoResizeTextarea(): void {
+  inputTextarea.style.height = 'auto'
+  const maxHeight = 200
+  const scrollHeight = Math.min(inputTextarea.scrollHeight, maxHeight)
+  inputTextarea.style.height = `${scrollHeight}px`
+}
+
+/** 更新发送按钮状态 */
+function updateSendButton(): void {
+  const hasContent = inputTextarea.value.trim().length > 0
+  if (isRunning) {
+    sendBtn.className = 'send-btn stop'
+    sendBtn.textContent = '■'
+    sendBtn.title = '停止生成'
+    sendBtn.disabled = false
+  } else {
+    sendBtn.className = 'send-btn'
+    sendBtn.textContent = '▶'
+    sendBtn.title = '发送'
+    sendBtn.disabled = !hasContent
+  }
+}
+
+/** 滚动到底部 */
+function scrollToBottom(): void {
+  requestAnimationFrame(() => {
+    messagesContainer.scrollTop = messagesContainer.scrollHeight
+  })
+}
+
+/** 格式化时间戳 */
+function formatTime(timestamp: number): string {
+  const date = new Date(timestamp)
+  const now = new Date()
+  const isToday = date.toDateString() === now.toDateString()
+  if (isToday) {
+    return date.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' })
+  }
+  return date.toLocaleDateString('zh-CN', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+/** HTML 转义 */
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/** 格式化权限请求输入 */
+function formatPermissionInput(toolName: string, input: Record<string, unknown>): string {
+  switch (toolName) {
+    case 'Bash':
+    case 'BashTool':
+      return `$ ${String(input.command ?? '')}`
+    case 'Write':
+    case 'FileWriteTool':
+      return `文件：${String(input.file_path ?? input.path ?? '')}`
+    case 'Edit':
+    case 'FileEditTool':
+      return `文件：${String(input.file_path ?? input.path ?? '')}`
+    default:
+      return JSON.stringify(input, null, 2).slice(0, 300)
+  }
+}
+
+/** 获取状态文本 */
+function getStatusText(status: string): string {
+  const map: Record<string, string> = {
+    pending: '等待',
+    approved: '已允许',
+    denied: '已拒绝',
+    completed: '完成',
+    error: '错误',
+    running: '执行中',
+  }
+  return map[status] ?? status
+}
+
+/**
+ * 简易 Markdown 渲染器
+ * 支持：代码块、内联代码、粗体、斜体、链接、有序/无序列表、标题、分隔线
+ */
+function renderMarkdown(text: string): string {
+  if (!text) return ''
+
+  // 处理代码块（```lang ... ```）
+  text = text.replace(/```(\w*)\n?([\s\S]*?)```/g, (_m, lang: string, code: string) => {
+    const escaped = escapeHtml(code.trim())
+    const langLabel = lang || 'code'
+    return `<pre><div class="code-block-header"><span>${langLabel}</span><button class="copy-btn" onclick="copyCode(this)">复制</button></div><code>${escaped}</code></pre>`
+  })
+
+  // 处理内联代码
+  text = text.replace(/`([^`]+)`/g, '<code>$1</code>')
+
+  // 处理标题
+  text = text.replace(/^### (.+)$/gm, '<h3>$1</h3>')
+  text = text.replace(/^## (.+)$/gm, '<h2>$1</h2>')
+  text = text.replace(/^# (.+)$/gm, '<h1>$1</h1>')
+
+  // 处理粗体
+  text = text.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+  text = text.replace(/__(.+?)__/g, '<strong>$1</strong>')
+
+  // 处理斜体
+  text = text.replace(/\*(.+?)\*/g, '<em>$1</em>')
+  text = text.replace(/_(.+?)_/g, '<em>$1</em>')
+
+  // 处理链接
+  text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank">$1</a>')
+
+  // 处理无序列表
+  text = text.replace(/^[*-] (.+)$/gm, '<li>$1</li>')
+  text = text.replace(/(<li>.*<\/li>\n?)+/g, '<ul>$&</ul>')
+
+  // 处理有序列表
+  text = text.replace(/^\d+\. (.+)$/gm, '<li>$1</li>')
+
+  // 处理分隔线
+  text = text.replace(/^---$/gm, '<hr>')
+
+  // 处理引用块
+  text = text.replace(/^> (.+)$/gm, '<blockquote>$1</blockquote>')
+
+  // 处理段落（双换行）
+  const paragraphs = text.split(/\n\n+/)
+  text = paragraphs
+    .map((p) => {
+      const trimmed = p.trim()
+      // 已经是块级元素则不包装
+      if (/^<(h[1-6]|pre|ul|ol|blockquote|hr)/.test(trimmed)) return trimmed
+      // 将单换行转为 <br>
+      return `<p>${trimmed.replace(/\n/g, '<br>')}</p>`
+    })
+    .join('\n')
+
+  return text
+}
+
+// 代码复制功能
+;(window as unknown as Record<string, unknown>)['copyCode'] = (btn: HTMLButtonElement) => {
+  const pre = btn.closest('pre')
+  const code = pre?.querySelector('code')?.textContent ?? ''
+  navigator.clipboard.writeText(code).then(() => {
+    const orig = btn.textContent
+    btn.textContent = '已复制!'
+    setTimeout(() => { btn.textContent = orig }, 2000)
+  })
+}

--- a/ide/vscode/src/webview/style.css
+++ b/ide/vscode/src/webview/style.css
@@ -1,0 +1,894 @@
+/* Claude Code VSCode 插件 WebView 样式
+ * 使用 VSCode CSS 变量适配主题（深色/浅色/高对比度）
+ */
+
+/* ===== 基础重置 ===== */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  /* 使用 VSCode 内置 CSS 变量 */
+  --claude-bg: var(--vscode-sideBar-background, #1e1e1e);
+  --claude-fg: var(--vscode-foreground, #cccccc);
+  --claude-border: var(--vscode-panel-border, #3c3c3c);
+  --claude-input-bg: var(--vscode-input-background, #3c3c3c);
+  --claude-input-fg: var(--vscode-input-foreground, #cccccc);
+  --claude-input-border: var(--vscode-input-border, #5a5a5a);
+  --claude-btn-bg: var(--vscode-button-background, #0e639c);
+  --claude-btn-fg: var(--vscode-button-foreground, #ffffff);
+  --claude-btn-hover: var(--vscode-button-hoverBackground, #1177bb);
+  --claude-link: var(--vscode-textLink-foreground, #3794ff);
+  --claude-code-bg: var(--vscode-textCodeBlock-background, #2d2d2d);
+  --claude-selection: var(--vscode-editor-selectionBackground, #264f78);
+  --claude-badge: var(--vscode-badge-background, #4d4d4d);
+  --claude-badge-fg: var(--vscode-badge-foreground, #ffffff);
+  --claude-warning: var(--vscode-editorWarning-foreground, #cca700);
+  --claude-error: var(--vscode-editorError-foreground, #f44747);
+  --claude-success: var(--vscode-testing-iconPassed, #73c991);
+  /* 用户消息气泡背景 */
+  --claude-user-bubble: var(--vscode-editor-selectionBackground, #264f7840);
+  /* 助手消息气泡背景 */
+  --claude-assistant-bubble: var(--vscode-editorWidget-background, #252526);
+  /* 圆角 */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  /* 间距 */
+  --spacing-xs: 4px;
+  --spacing-sm: 8px;
+  --spacing-md: 12px;
+  --spacing-lg: 16px;
+  --spacing-xl: 24px;
+}
+
+html, body {
+  height: 100%;
+  font-family: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  font-size: var(--vscode-font-size, 13px);
+  color: var(--claude-fg);
+  background: var(--claude-bg);
+  overflow: hidden;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* ===== 头部工具栏 ===== */
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-bottom: 1px solid var(--claude-border);
+  flex-shrink: 0;
+  gap: var(--spacing-sm);
+}
+
+.toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  overflow: hidden;
+}
+
+.toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  flex-shrink: 0;
+}
+
+.session-title {
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--claude-fg);
+  opacity: 0.8;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 10px;
+  background: var(--claude-badge);
+  color: var(--claude-badge-fg);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.status-badge.running {
+  background: var(--claude-btn-bg);
+  color: var(--claude-btn-fg);
+}
+
+.status-badge.error {
+  background: var(--claude-error);
+  color: #fff;
+}
+
+.status-badge.waiting {
+  background: var(--claude-warning);
+  color: #000;
+}
+
+/* ===== 图标按钮 ===== */
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  color: var(--claude-fg);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  opacity: 0.7;
+  transition: opacity 0.15s, background 0.15s;
+  flex-shrink: 0;
+}
+
+.icon-btn:hover {
+  opacity: 1;
+  background: var(--vscode-toolbar-hoverBackground, rgba(255,255,255,0.1));
+}
+
+.icon-btn:active {
+  opacity: 0.8;
+}
+
+.icon-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+/* ===== 消息列表区域 ===== */
+.messages-container {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: var(--spacing-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  scroll-behavior: smooth;
+}
+
+/* 滚动条样式 */
+.messages-container::-webkit-scrollbar {
+  width: 6px;
+}
+.messages-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+.messages-container::-webkit-scrollbar-thumb {
+  background: var(--claude-border);
+  border-radius: 3px;
+}
+.messages-container::-webkit-scrollbar-thumb:hover {
+  background: var(--vscode-scrollbarSlider-hoverBackground, #5a5a5a);
+}
+
+/* ===== 欢迎屏幕 ===== */
+.welcome-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: var(--spacing-lg);
+  opacity: 0.7;
+  padding: var(--spacing-xl);
+  text-align: center;
+}
+
+.welcome-icon {
+  font-size: 48px;
+  opacity: 0.5;
+}
+
+.welcome-title {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.welcome-desc {
+  font-size: 12px;
+  line-height: 1.6;
+  opacity: 0.8;
+}
+
+.welcome-tips {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  width: 100%;
+  max-width: 240px;
+}
+
+.tip-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: 11px;
+  background: var(--claude-assistant-bubble);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  text-align: left;
+  cursor: pointer;
+  border: 1px solid var(--claude-border);
+  color: var(--claude-fg);
+  transition: background 0.15s;
+}
+
+.tip-item:hover {
+  background: var(--vscode-list-hoverBackground, rgba(255,255,255,0.05));
+}
+
+/* ===== 消息气泡 ===== */
+.message {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  animation: fadeInUp 0.2s ease;
+}
+
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.message.user {
+  align-items: flex-end;
+}
+
+.message.assistant {
+  align-items: flex-start;
+}
+
+.message.system {
+  align-items: center;
+}
+
+/* 消息发送者标签 */
+.message-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: 11px;
+  opacity: 0.6;
+  padding: 0 var(--spacing-xs);
+}
+
+.message.user .message-header {
+  flex-direction: row-reverse;
+}
+
+/* 消息气泡主体 */
+.message-bubble {
+  max-width: 90%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-lg);
+  line-height: 1.6;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  position: relative;
+}
+
+.message.user .message-bubble {
+  background: var(--claude-user-bubble);
+  border: 1px solid var(--claude-selection);
+  border-bottom-right-radius: var(--radius-sm);
+}
+
+.message.assistant .message-bubble {
+  background: var(--claude-assistant-bubble);
+  border: 1px solid var(--claude-border);
+  border-bottom-left-radius: var(--radius-sm);
+  max-width: 100%;
+  width: 100%;
+}
+
+.message.system .message-bubble {
+  background: transparent;
+  border: none;
+  font-size: 11px;
+  color: var(--claude-fg);
+  opacity: 0.5;
+  font-style: italic;
+  text-align: center;
+  padding: var(--spacing-xs) 0;
+}
+
+/* 流式输出光标动画 */
+.message-bubble.streaming::after {
+  content: '▋';
+  display: inline-block;
+  animation: blink 0.8s step-end infinite;
+  color: var(--claude-btn-bg);
+  margin-left: 2px;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* ===== Markdown 渲染样式 ===== */
+.message-bubble p {
+  margin-bottom: var(--spacing-sm);
+}
+
+.message-bubble p:last-child {
+  margin-bottom: 0;
+}
+
+.message-bubble code {
+  font-family: var(--vscode-editor-font-family, 'Cascadia Code', 'Courier New', monospace);
+  font-size: 0.9em;
+  background: var(--claude-code-bg);
+  padding: 1px 4px;
+  border-radius: var(--radius-sm);
+  color: var(--vscode-textPreformat-foreground, #d7ba7d);
+}
+
+.message-bubble pre {
+  background: var(--claude-code-bg);
+  border: 1px solid var(--claude-border);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-md);
+  overflow-x: auto;
+  margin: var(--spacing-sm) 0;
+  position: relative;
+}
+
+.message-bubble pre code {
+  background: transparent;
+  padding: 0;
+  color: var(--claude-fg);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+/* 代码块复制按钮 */
+.code-block-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(255,255,255,0.05);
+  border-bottom: 1px solid var(--claude-border);
+  padding: var(--spacing-xs) var(--spacing-md);
+  margin: calc(-1 * var(--spacing-md)) calc(-1 * var(--spacing-md)) var(--spacing-md);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.copy-btn {
+  background: transparent;
+  border: none;
+  color: var(--claude-fg);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  opacity: 0.7;
+}
+
+.copy-btn:hover { opacity: 1; }
+
+.message-bubble h1, .message-bubble h2, .message-bubble h3 {
+  margin: var(--spacing-md) 0 var(--spacing-sm);
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.message-bubble h1 { font-size: 1.2em; }
+.message-bubble h2 { font-size: 1.1em; }
+.message-bubble h3 { font-size: 1em; }
+
+.message-bubble ul, .message-bubble ol {
+  padding-left: var(--spacing-lg);
+  margin: var(--spacing-sm) 0;
+}
+
+.message-bubble li {
+  margin-bottom: var(--spacing-xs);
+  line-height: 1.6;
+}
+
+.message-bubble blockquote {
+  border-left: 3px solid var(--claude-btn-bg);
+  padding-left: var(--spacing-md);
+  margin: var(--spacing-sm) 0;
+  opacity: 0.8;
+  font-style: italic;
+}
+
+.message-bubble a {
+  color: var(--claude-link);
+  text-decoration: none;
+}
+
+.message-bubble a:hover {
+  text-decoration: underline;
+}
+
+.message-bubble table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: var(--spacing-sm) 0;
+  font-size: 12px;
+}
+
+.message-bubble th, .message-bubble td {
+  border: 1px solid var(--claude-border);
+  padding: 4px 8px;
+  text-align: left;
+}
+
+.message-bubble th {
+  background: rgba(255,255,255,0.05);
+  font-weight: 600;
+}
+
+/* ===== 工具调用区域 ===== */
+.tool-calls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  margin-top: var(--spacing-sm);
+}
+
+.tool-call {
+  border: 1px solid var(--claude-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  font-size: 11px;
+}
+
+.tool-call-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-md);
+  background: rgba(255,255,255,0.03);
+  cursor: pointer;
+  user-select: none;
+}
+
+.tool-call-icon {
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.tool-call-name {
+  font-weight: 600;
+  color: var(--claude-link);
+}
+
+.tool-call-status {
+  margin-left: auto;
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 8px;
+}
+
+.tool-call-status.pending { background: var(--claude-badge); color: var(--claude-badge-fg); }
+.tool-call-status.approved { background: var(--claude-success); color: #000; }
+.tool-call-status.denied { background: var(--claude-error); color: #fff; }
+.tool-call-status.completed { background: var(--claude-success); color: #000; }
+.tool-call-status.error { background: var(--claude-error); color: #fff; }
+
+.tool-call-body {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--claude-code-bg);
+  display: none;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.tool-call.expanded .tool-call-body {
+  display: block;
+}
+
+.tool-call-result {
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-top: 1px solid var(--claude-border);
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 100px;
+  overflow-y: auto;
+  opacity: 0.8;
+}
+
+.tool-call-result.error {
+  color: var(--claude-error);
+}
+
+/* ===== 思考过程区域 ===== */
+.thinking-block {
+  border: 1px dashed var(--claude-border);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--spacing-sm);
+  overflow: hidden;
+}
+
+.thinking-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: 11px;
+  opacity: 0.6;
+  cursor: pointer;
+  background: rgba(255,255,255,0.02);
+}
+
+.thinking-content {
+  padding: var(--spacing-md);
+  font-size: 11px;
+  opacity: 0.7;
+  white-space: pre-wrap;
+  display: none;
+  font-style: italic;
+  line-height: 1.6;
+}
+
+.thinking-block.expanded .thinking-content {
+  display: block;
+}
+
+/* ===== 权限审批区域 ===== */
+.permission-card {
+  border: 1px solid var(--claude-warning);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  margin: var(--spacing-sm) 0;
+  animation: fadeInUp 0.2s ease;
+}
+
+.permission-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: rgba(204, 167, 0, 0.1);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--claude-warning);
+}
+
+.permission-body {
+  padding: var(--spacing-md);
+}
+
+.permission-tool-name {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--claude-link);
+  margin-bottom: var(--spacing-sm);
+}
+
+.permission-input {
+  background: var(--claude-code-bg);
+  border: 1px solid var(--claude-border);
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-sm);
+  font-size: 11px;
+  font-family: var(--vscode-editor-font-family, monospace);
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 120px;
+  overflow-y: auto;
+  margin-bottom: var(--spacing-md);
+}
+
+.permission-actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.permission-remember {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: 11px;
+  margin-left: auto;
+  cursor: pointer;
+}
+
+.permission-remember input {
+  cursor: pointer;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: 4px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+  font-family: inherit;
+}
+
+.btn-primary {
+  background: var(--claude-btn-bg);
+  color: var(--claude-btn-fg);
+  border-color: var(--claude-btn-bg);
+}
+
+.btn-primary:hover { background: var(--claude-btn-hover); }
+
+.btn-danger {
+  background: transparent;
+  color: var(--claude-error);
+  border-color: var(--claude-error);
+}
+
+.btn-danger:hover { background: rgba(244, 71, 71, 0.1); }
+
+.btn-secondary {
+  background: var(--vscode-button-secondaryBackground, #3a3d41);
+  color: var(--vscode-button-secondaryForeground, #cccccc);
+  border-color: var(--claude-border);
+}
+
+.btn-secondary:hover { background: var(--vscode-button-secondaryHoverBackground, #45494e); }
+
+/* ===== 输入区域 ===== */
+.input-area {
+  flex-shrink: 0;
+  border-top: 1px solid var(--claude-border);
+  padding: var(--spacing-sm) var(--spacing-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  background: var(--claude-bg);
+}
+
+.input-wrapper {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-sm);
+  background: var(--claude-input-bg);
+  border: 1px solid var(--claude-input-border);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm);
+  transition: border-color 0.15s;
+}
+
+.input-wrapper:focus-within {
+  border-color: var(--vscode-focusBorder, #007fd4);
+}
+
+.message-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--claude-input-fg);
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.5;
+  resize: none;
+  min-height: 20px;
+  max-height: 200px;
+  overflow-y: auto;
+  word-break: break-word;
+}
+
+.message-input::placeholder {
+  color: var(--vscode-input-placeholderForeground, #8c8c8c);
+}
+
+.send-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: var(--claude-btn-bg);
+  color: var(--claude-btn-fg);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s, opacity 0.15s;
+  font-size: 14px;
+}
+
+.send-btn:hover:not(:disabled) {
+  background: var(--claude-btn-hover);
+}
+
+.send-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.send-btn.stop {
+  background: var(--claude-error);
+}
+
+.send-btn.stop:hover {
+  background: #cc3333;
+}
+
+/* 输入提示文字 */
+.input-hint {
+  font-size: 10px;
+  color: var(--claude-fg);
+  opacity: 0.4;
+  text-align: right;
+}
+
+/* ===== 加载动画 ===== */
+.loading-dots {
+  display: flex;
+  gap: 4px;
+  padding: var(--spacing-sm) var(--spacing-md);
+  align-items: center;
+}
+
+.loading-dots span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--claude-fg);
+  opacity: 0.3;
+  animation: loadingDot 1.4s ease-in-out infinite;
+}
+
+.loading-dots span:nth-child(1) { animation-delay: 0s; }
+.loading-dots span:nth-child(2) { animation-delay: 0.2s; }
+.loading-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes loadingDot {
+  0%, 80%, 100% { opacity: 0.3; transform: scale(1); }
+  40% { opacity: 1; transform: scale(1.2); }
+}
+
+/* ===== 会话历史面板 ===== */
+.sessions-panel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--claude-bg);
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sessions-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-md);
+  border-bottom: 1px solid var(--claude-border);
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.sessions-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--spacing-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.session-item {
+  display: flex;
+  align-items: center;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  border: 1px solid transparent;
+  gap: var(--spacing-sm);
+  transition: background 0.15s;
+}
+
+.session-item:hover {
+  background: var(--vscode-list-hoverBackground, rgba(255,255,255,0.05));
+  border-color: var(--claude-border);
+}
+
+.session-item.active {
+  background: var(--vscode-list-activeSelectionBackground, rgba(14, 99, 156, 0.2));
+  border-color: var(--claude-btn-bg);
+}
+
+.session-item-content {
+  flex: 1;
+  overflow: hidden;
+}
+
+.session-item-title {
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-item-meta {
+  font-size: 10px;
+  opacity: 0.5;
+  margin-top: 1px;
+}
+
+.session-delete-btn {
+  opacity: 0;
+  color: var(--claude-error);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.session-item:hover .session-delete-btn {
+  opacity: 0.7;
+}
+
+.session-delete-btn:hover {
+  opacity: 1 !important;
+}
+
+/* ===== 空状态 ===== */
+.empty-sessions {
+  text-align: center;
+  opacity: 0.5;
+  font-size: 12px;
+  padding: var(--spacing-xl);
+}
+
+/* ===== 响应式适配（窄侧边栏） ===== */
+@media (max-width: 280px) {
+  .message-bubble {
+    max-width: 100%;
+  }
+  .toolbar {
+    padding: var(--spacing-xs) var(--spacing-sm);
+  }
+}
+
+/* ===== 可访问性 ===== */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+/* 焦点样式 */
+:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder, #007fd4);
+  outline-offset: 1px;
+}

--- a/ide/vscode/tsconfig.json
+++ b/ide/vscode/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationDir": "./dist/types"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
- 新增 ide/vscode/ VSCode 扩展，提供 Claude Code 的 IDE 集成
- 包含 ChatViewProvider、StatusBarProvider、SessionManager、PermissionManager 等核心模块
- 支持 Webview 聊天界面和状态栏集成
- 更新 .gitignore，忽略 .omc/ 和 .claude/settings.local.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched VS Code extension for Claude Code with an integrated sidebar chat panel.
  * Added support for multiple AI providers: Anthropic, OpenAI, Gemini, Bedrock, Vertex, and Grok.
  * Enabled sending selected code for explanation, refactoring, and fixing directly from the editor.
  * Integrated session and conversation history management with persistent storage.
  * Added tool permission approval UI for controlled execution of suggested changes.

* **Documentation**
  * Added comprehensive README with installation, configuration, and usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->