### PR TITLE
修复使用openai类型接口，第一次调用失败的bug

### DIFF
--- a/packages/@ant/model-provider/src/shared/openaiConvertMessages.ts
+++ b/packages/@ant/model-provider/src/shared/openaiConvertMessages.ts
@@ -260,7 +260,7 @@ function convertInternalAssistantMessage(
 
   const result: ChatCompletionAssistantMessageParam = {
     role: 'assistant',
-    content: textParts.length > 0 ? textParts.join('\n') : null,
+    content: textParts.length > 0 ? textParts.join('\n') : "",
     ...(toolCalls.length > 0 && { tool_calls: toolCalls }),
     ...(reasoningParts.length > 0 && { reasoning_content: reasoningParts.join('\n') }),
   }

--- a/src/services/api/openai/client.ts
+++ b/src/services/api/openai/client.ts
@@ -1,6 +1,5 @@
-import OpenAI from 'openai'
+import type OpenAI from 'openai
 import { getProxyFetchOptions } from 'src/utils/proxy.js'
-import { isEnvTruthy } from 'src/utils/envUtils.js'
 
 /**
  * Environment variables:
@@ -13,13 +12,14 @@ import { isEnvTruthy } from 'src/utils/envUtils.js'
 
 let cachedClient: OpenAI | null = null
 
-export function getOpenAIClient(options?: {
+export async function getOpenAIClient(options?: {  
   maxRetries?: number
   fetchOverride?: typeof fetch
   source?: string
-}): OpenAI {
+}): Promise<OpenAI> {
   if (cachedClient) return cachedClient
-
+	
+  const { default: OpenAI } = await import('openai') 
   const apiKey = process.env.OPENAI_API_KEY || ''
   const baseURL = process.env.OPENAI_BASE_URL
 

--- a/src/services/api/openai/index.ts
+++ b/src/services/api/openai/index.ts
@@ -217,7 +217,7 @@ export async function* queryModelOpenAI(
     const maxTokens = resolveOpenAIMaxTokens(upperLimit, options.maxOutputTokensOverride)
 
     // 11. Get client
-    const client = getOpenAIClient({
+    const client = await getOpenAIClient({     
       maxRetries: 0,
       fetchOverride: options.fetchOverride as unknown as typeof fetch,
       source: options.querySource,


### PR DESCRIPTION
<img width="1090" height="412" alt="20260420152601312" src="https://github.com/user-attachments/assets/6876dfb6-79dd-4f07-8772-25cbddf9c65a" />
配置openai 兼容的api接口，因为加载问题，第一次运行恒定报错。尤其在通过-p等全自动化的方式调用的时候影响极大

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved OpenAI client initialization to be asynchronous for more reliable/performant request handling.

* **Bug Fixes**
  * Assistant responses now always provide an empty string instead of null for empty content, preventing unexpected null content in outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->