### PR TITLE
feat: 启用 SKILL_LEARNING 编译开关

### DIFF
--- a/scripts/defines.ts
+++ b/scripts/defines.ts
@@ -66,8 +66,9 @@ export const DEFAULT_BUILD_FEATURES = [
     'COMMIT_ATTRIBUTION',          // Git 提交归属追踪（记录 AI 辅助贡献）
     // Server mode (claude server / claude open)
     'DIRECT_CONNECT',              // 直连模式（claude server / claude open）
-    // Skill search
+    // Skill search & learning
     'EXPERIMENTAL_SKILL_SEARCH',   // 实验性技能搜索（DiscoverSkills）
+    'SKILL_LEARNING',              // 技能学习系统，从对话中自动生成/演化技能
     // P3: poor mode
     'POOR',                        // 穷鬼模式，跳过 extract_memories/prompt_suggestion 减少消耗
     // Team Memory


### PR DESCRIPTION
## Summary

- 将 `SKILL_LEARNING` 加入 `DEFAULT_BUILD_FEATURES`，构建产物中默认启用技能学习系统
- 此前该功能仅在 dev 模式下可用（dev 模式默认启用所有 feature），构建产物中因缺少编译开关导致 Skill Learning 不显示

## Test plan

- [ ] `bun run build` 构建后验证 `feature('SKILL_LEARNING')` 返回 `true`
- [ ] 构建产物中 `/learn` 命令可用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skill learning is now enabled by default. This feature integrates seamlessly with skill search to provide a comprehensive platform for discovering and developing new skills. Users can explore, discover, and actively learn new professional competencies, enhancing their ability to grow and develop new capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->