### PR TITLE
docs: clarify Bun setup without duplicate steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,27 +75,24 @@ powershell -c "irm bun.sh/install.ps1 | iex"
 
 **安装后的操作：**
 
-1. **重启终端** 或重新加载 shell 配置文件：
-   ```bash
-   # macOS/Linux (zsh)
-   source ~/.zshrc
-   
-   # macOS/Linux (bash)
-   source ~/.bashrc
-   
-   # Windows PowerShell
-   # 关闭并重新打开 PowerShell 即可
-   ```
+Bun 安装脚本会将 `~/.bun/bin` 添加到对应的 shell 配置文件中，例如 zsh 环境下会显示：
 
-2. **验证安装：**
-   ```bash
-   bun --version
-   ```
+```text
+Added "~/.bun/bin" to $PATH in "~/.zshrc"
+```
 
-3. **更新到最新版本（如果已安装）：**
-   ```bash
-   bun upgrade
-   ```
+To get started, run:
+
+```bash
+exec /bin/zsh
+bun --help
+```
+
+如果已经安装过 Bun，可以更新到最新版本：
+
+```bash
+bun upgrade
+```
 
 - ⚙️ 常规的配置 CC 的方式, 各大提供商都有自己的配置方式
 

--- a/README.md
+++ b/README.md
@@ -75,30 +75,53 @@ powershell -c "irm bun.sh/install.ps1 | iex"
 
 **安装后的操作：**
 
-Bun 安装脚本会将 `~/.bun/bin` 添加到对应的 shell 配置文件中，例如 zsh 环境下会显示：
+1. **让当前终端识别 `bun` 命令**
 
-```text
-Added "~/.bun/bin" to $PATH in "~/.zshrc"
-```
+   安装脚本会把 `~/.bun/bin` 写入对应的 shell 配置文件。macOS 默认 zsh 环境通常会看到：
 
-To get started, run:
+   ```text
+   Added "~/.bun/bin" to $PATH in "~/.zshrc"
+   ```
 
-```bash
-exec /bin/zsh
-bun --help
-```
+   可以按安装脚本提示重启当前 shell：
 
-如果已经安装过 Bun，可以更新到最新版本：
+   ```bash
+   exec /bin/zsh
+   ```
 
-```bash
-bun upgrade
-```
+   如果你使用 bash，重新加载 bash 配置：
+
+   ```bash
+   source ~/.bashrc
+   ```
+
+   Windows PowerShell 用户关闭并重新打开 PowerShell 即可。
+
+2. **验证 Bun 是否可用**
+
+   ```bash
+   bun --help
+   bun --version
+   ```
+
+3. **如果已经安装过 Bun，更新到最新版本**
+
+   ```bash
+   bun upgrade
+   ```
 
 - ⚙️ 常规的配置 CC 的方式, 各大提供商都有自己的配置方式
+
+### 📍 命令执行位置
+
+- 安装或检查 Bun 的命令可以在任意目录执行：
+  `curl -fsSL https://bun.sh/install | bash`、`bun --help`、`bun --version`、`bun upgrade`
+- 安装本项目依赖、启动开发模式、构建项目时，必须先进入本仓库根目录，也就是包含 `package.json` 的目录。
 
 ### 📥 安装
 
 ```bash
+cd /path/to/claude-code
 bun install
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -61,20 +61,31 @@ powershell -c "irm bun.sh/install.ps1 | iex"
 
 **Post-installation steps:**
 
-1. **Restart your terminal** or reload your shell configuration:
-   ```bash
-   # macOS/Linux (zsh)
-   source ~/.zshrc
+1. **Make `bun` available in the current terminal**
 
-   # macOS/Linux (bash)
-   source ~/.bashrc
+   The installer adds `~/.bun/bin` to the matching shell configuration file. On macOS with the default zsh shell, you may see:
 
-   # Windows PowerShell
-   # Close and reopen PowerShell
+   ```text
+   Added "~/.bun/bin" to $PATH in "~/.zshrc"
    ```
 
-2. **Verify installation:**
+   Restart the current shell as the installer suggests:
+
    ```bash
+   exec /bin/zsh
+   ```
+
+   If you use bash, reload the bash configuration:
+
+   ```bash
+   source ~/.bashrc
+   ```
+
+   Windows PowerShell users can close and reopen PowerShell.
+
+2. **Verify that Bun is available:**
+   ```bash
+   bun --help
    bun --version
    ```
 
@@ -85,9 +96,16 @@ powershell -c "irm bun.sh/install.ps1 | iex"
 
 - Standard Claude Code configuration — each provider has its own setup method
 
+### Command Execution Location
+
+- Bun installation and checking commands can be run from any directory:
+  `curl -fsSL https://bun.sh/install | bash`, `bun --help`, `bun --version`, `bun upgrade`
+- Project dependency installation, development mode, and builds must be run from this repository root, the directory containing `package.json`.
+
 ### Install
 
 ```bash
+cd /path/to/claude-code
 bun install
 ```
 


### PR DESCRIPTION
## Summary
- clarify Bun post-install steps without duplicating the installer output
- explain where to run Bun setup/check commands versus project commands
- keep README.md and README_EN.md aligned

## Test Plan
- docs-only change
- verified PR diff only includes README.md and README_EN.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Bun installation instructions with clearer PATH configuration guidance for different shells (zsh, bash, PowerShell).
  * Added clarification on command execution locations: installation and build steps require the repository root containing `package.json`, while general Bun commands work from any directory.
  * Enhanced installation verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->