### PR TITLE
fix: keep UDS peer failures structured

### DIFF
--- a/src/services/AgentSummary/__tests__/agentSummary.test.ts
+++ b/src/services/AgentSummary/__tests__/agentSummary.test.ts
@@ -161,7 +161,9 @@ describe('startAgentSummarization', () => {
 
     expect(forkCalls).toEqual([])
     expect(updateCalls).toEqual([])
-    expectDebugLogContaining('no bounded context available')
+    expectDebugLogContaining(
+      '[AgentSummary] Skipping summary for task-1: no bounded context available',
+    )
   })
 
   test('skips summarization before building context when transcript is too short', async () => {
@@ -173,7 +175,9 @@ describe('startAgentSummarization', () => {
 
     expect(forkCalls).toEqual([])
     expect(updateCalls).toEqual([])
-    expectDebugLogContaining('not enough messages (2)')
+    expectDebugLogContaining(
+      '[AgentSummary] Skipping summary for task-1: not enough messages (2)',
+    )
   })
 
   test('skips and reschedules while poor mode is active', async () => {
@@ -188,7 +192,7 @@ describe('startAgentSummarization', () => {
 
     expect(forkCalls).toEqual([])
     expect(updateCalls).toEqual([])
-    expectDebugLogContaining('poor mode active')
+    expectDebugLogContaining('[AgentSummary] Skipping summary — poor mode active')
     expect(scheduledCount).toBe(initialScheduledCount + 1)
     expect(lastTimerHandle).not.toBe(initialTimerHandle)
   })
@@ -218,7 +222,7 @@ describe('startAgentSummarization', () => {
 
     handle.stop()
 
-    expectDebugLogContaining('Stopping summarization for task-1')
+    expectDebugLogContaining('[AgentSummary] Stopping summarization for task-1')
     expect(clearedHandles).toEqual([pendingHandle])
   })
 })

--- a/src/services/AgentSummary/__tests__/agentSummary.test.ts
+++ b/src/services/AgentSummary/__tests__/agentSummary.test.ts
@@ -109,6 +109,10 @@ describe('startAgentSummarization', () => {
     lastTimerHandle = undefined
   })
 
+  function expectDebugLogContaining(fragment: string): void {
+    expect(debugLogs.some(message => message.includes(fragment))).toBe(true)
+  }
+
   test('summarizes bounded transcript once and skips unchanged fingerprints', async () => {
     handle = startTestSummarization()
 
@@ -157,9 +161,7 @@ describe('startAgentSummarization', () => {
 
     expect(forkCalls).toEqual([])
     expect(updateCalls).toEqual([])
-    expect(debugLogs).toContain(
-      '[AgentSummary] Skipping summary for task-1: no bounded context available',
-    )
+    expectDebugLogContaining('no bounded context available')
   })
 
   test('skips summarization before building context when transcript is too short', async () => {
@@ -171,9 +173,7 @@ describe('startAgentSummarization', () => {
 
     expect(forkCalls).toEqual([])
     expect(updateCalls).toEqual([])
-    expect(debugLogs).toContain(
-      '[AgentSummary] Skipping summary for task-1: not enough messages (2)',
-    )
+    expectDebugLogContaining('not enough messages (2)')
   })
 
   test('skips and reschedules while poor mode is active', async () => {
@@ -188,9 +188,7 @@ describe('startAgentSummarization', () => {
 
     expect(forkCalls).toEqual([])
     expect(updateCalls).toEqual([])
-    expect(debugLogs).toContain(
-      '[AgentSummary] Skipping summary — poor mode active',
-    )
+    expectDebugLogContaining('poor mode active')
     expect(scheduledCount).toBe(initialScheduledCount + 1)
     expect(lastTimerHandle).not.toBe(initialTimerHandle)
   })
@@ -220,9 +218,7 @@ describe('startAgentSummarization', () => {
 
     handle.stop()
 
-    expect(debugLogs).toContain(
-      '[AgentSummary] Stopping summarization for task-1',
-    )
+    expectDebugLogContaining('Stopping summarization for task-1')
     expect(clearedHandles).toEqual([pendingHandle])
   })
 })

--- a/src/utils/__tests__/teammateMailbox.test.ts
+++ b/src/utils/__tests__/teammateMailbox.test.ts
@@ -365,7 +365,11 @@ describe('teammate mailbox retention', () => {
     if (code === undefined) {
       throw new Error('Expected filesystem errno code')
     }
-    expect(['EISDIR', 'EPERM', 'EACCES']).toContain(code)
+    const expectedCodes =
+      process.platform === 'win32'
+        ? ['EISDIR', 'EPERM', 'EACCES']
+        : ['EISDIR']
+    expect(expectedCodes).toContain(code)
     expect((await stat(inboxPath)).isDirectory()).toBe(true)
   })
 

--- a/src/utils/__tests__/udsMessaging.test.ts
+++ b/src/utils/__tests__/udsMessaging.test.ts
@@ -340,7 +340,7 @@ describe('UDS inbox retention', () => {
     let client: Socket | undefined
     try {
       const { connectToPeer } = await import('../udsClient.js')
-      client = await connectToPeer(path, 50)
+      client = await connectToPeer(path, 1000)
       await new Promise(resolve => setTimeout(resolve, 100))
 
       expect(client.destroyed).toBe(false)

--- a/src/utils/__tests__/udsMessaging.test.ts
+++ b/src/utils/__tests__/udsMessaging.test.ts
@@ -275,7 +275,7 @@ describe('UDS inbox retention', () => {
         '../udsClient.js'
       )
 
-      const error = await sendToUdsSocket(path, 'hello', 50).then(
+      const error = await sendToUdsSocket(path, 'hello', 200).then(
         () => undefined,
         err => err,
       )
@@ -291,6 +291,62 @@ describe('UDS inbox retention', () => {
       expect(error.cause.message).toBe('Connection timed out')
       expect(error.message).not.toContain('test-token')
     } finally {
+      for (const socket of sockets) {
+        socket.destroy()
+      }
+      await closeServer(receiver)
+      if (process.platform !== 'win32') {
+        await unlink(path).catch(() => undefined)
+      }
+    }
+  })
+
+  test('connectToPeer reports connection failures as peer connection errors', async () => {
+    const path = socketPath('uds-connect-error')
+    const { connectToPeer, UdsPeerConnectionError } = await import(
+      '../udsClient.js'
+    )
+
+    const error = await connectToPeer(path).then(
+      () => undefined,
+      err => err,
+    )
+
+    expect(error).toBeInstanceOf(UdsPeerConnectionError)
+    if (!(error instanceof UdsPeerConnectionError)) {
+      throw new Error('Expected UDS peer connection error')
+    }
+    expect(error.socketPath).toBe(path)
+  })
+
+  test('connectToPeer leaves connected socket lifecycle to the caller', async () => {
+    const path = socketPath('uds-connect-lifecycle')
+    if (process.platform !== 'win32') {
+      await mkdir(dirname(path), { recursive: true })
+    }
+
+    const sockets = new Set<Socket>()
+    const receiver = createServer(socket => {
+      sockets.add(socket)
+      socket.on('close', () => {
+        sockets.delete(socket)
+      })
+    })
+    await new Promise<void>((resolve, reject) => {
+      receiver.on('error', reject)
+      receiver.listen(path, () => resolve())
+    })
+
+    let client: Socket | undefined
+    try {
+      const { connectToPeer } = await import('../udsClient.js')
+      client = await connectToPeer(path, 50)
+      await new Promise(resolve => setTimeout(resolve, 100))
+
+      expect(client.destroyed).toBe(false)
+      expect(client.listenerCount('error')).toBe(0)
+    } finally {
+      client?.destroy()
       for (const socket of sockets) {
         socket.destroy()
       }

--- a/src/utils/__tests__/udsMessaging.test.ts
+++ b/src/utils/__tests__/udsMessaging.test.ts
@@ -307,7 +307,9 @@ describe('UDS inbox retention', () => {
       '../udsClient.js'
     )
 
-    const error = await connectToPeer(path).then(
+    const error = await connectToPeer(path, () => {
+      throw new Error('Unexpected post-connect socket error')
+    }).then(
       () => undefined,
       err => err,
     )
@@ -338,13 +340,25 @@ describe('UDS inbox retention', () => {
     })
 
     let client: Socket | undefined
+    const socketErrors: Error[] = []
     try {
       const { connectToPeer } = await import('../udsClient.js')
-      client = await connectToPeer(path, 1000)
+      client = await connectToPeer(
+        path,
+        error => {
+          socketErrors.push(error)
+        },
+        1000,
+      )
       await new Promise(resolve => setTimeout(resolve, 100))
 
       expect(client.destroyed).toBe(false)
-      expect(client.listenerCount('error')).toBe(0)
+      expect(client.listenerCount('error')).toBe(1)
+      expect(client.listenerCount('timeout')).toBe(0)
+
+      const socketError = new Error('post-connect failure')
+      client.emit('error', socketError)
+      expect(socketErrors).toEqual([socketError])
     } finally {
       client?.destroy()
       for (const socket of sockets) {

--- a/src/utils/__tests__/udsMessaging.test.ts
+++ b/src/utils/__tests__/udsMessaging.test.ts
@@ -354,7 +354,6 @@ describe('UDS inbox retention', () => {
 
       expect(client.destroyed).toBe(false)
       expect(client.listenerCount('error')).toBe(1)
-      expect(client.listenerCount('timeout')).toBe(0)
 
       const socketError = new Error('post-connect failure')
       client.emit('error', socketError)

--- a/src/utils/udsClient.ts
+++ b/src/utils/udsClient.ts
@@ -280,13 +280,14 @@ export function connectToPeer(
   return new Promise<Socket>((resolve, reject) => {
     const conn = createConnection(socketPath)
     let settled = false
-    const onTimeout = () => {
-      fail(new Error('Connection timed out'))
-    }
+    const timeout = setTimeout(
+      fail,
+      timeoutMs,
+      new Error('Connection timed out'),
+    )
     function cleanupListeners(): void {
-      conn.setTimeout(0)
+      clearTimeout(timeout)
       conn.off('error', fail)
-      conn.off('timeout', onTimeout)
     }
     function fail(cause: unknown): void {
       if (settled) {
@@ -307,8 +308,6 @@ export function connectToPeer(
       resolve(conn)
     })
     conn.on('error', fail)
-    conn.once('timeout', onTimeout)
-    conn.setTimeout(timeoutMs)
   })
 }
 

--- a/src/utils/udsClient.ts
+++ b/src/utils/udsClient.ts
@@ -266,7 +266,10 @@ export async function sendToUdsSocket(
 
 /**
  * Connect to a peer and return the raw socket for bidirectional communication.
- * The caller is responsible for managing the connection lifecycle.
+ * The caller is responsible for managing the connection lifecycle, including
+ * attaching an 'error' listener immediately after the Promise resolves. This
+ * function detaches its internal error listener on successful connect so
+ * caller-owned socket errors are not silently swallowed.
  */
 export function connectToPeer(
   socketPath: string,

--- a/src/utils/udsClient.ts
+++ b/src/utils/udsClient.ts
@@ -268,14 +268,30 @@ export async function sendToUdsSocket(
  * Connect to a peer and return the raw socket for bidirectional communication.
  * The caller is responsible for managing the connection lifecycle.
  */
-export function connectToPeer(socketPath: string): Promise<Socket> {
+export function connectToPeer(
+  socketPath: string,
+  timeoutMs = 5000,
+): Promise<Socket> {
   return new Promise<Socket>((resolve, reject) => {
-    const conn = createConnection(socketPath, () => {
+    const conn = createConnection(socketPath)
+    let settled = false
+    const fail = (cause: unknown) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      conn.destroy()
+      reject(new UdsPeerConnectionError(socketPath, cause))
+    }
+    conn.once('connect', () => {
+      settled = true
+      conn.setTimeout(0)
+      conn.off('error', fail)
       resolve(conn)
     })
-    conn.on('error', reject)
-    conn.setTimeout(5000, () => {
-      conn.destroy(new Error('Connection timed out'))
+    conn.on('error', fail)
+    conn.setTimeout(timeoutMs, () => {
+      fail(new Error('Connection timed out'))
     })
   })
 }

--- a/src/utils/udsClient.ts
+++ b/src/utils/udsClient.ts
@@ -266,36 +266,49 @@ export async function sendToUdsSocket(
 
 /**
  * Connect to a peer and return the raw socket for bidirectional communication.
- * The caller is responsible for managing the connection lifecycle, including
- * attaching an 'error' listener immediately after the Promise resolves. This
- * function detaches its internal error listener on successful connect so
- * caller-owned socket errors are not silently swallowed.
+ * The caller owns the post-connect lifecycle through onSocketError, which is
+ * attached before the Promise resolves so peer socket errors cannot be
+ * swallowed or surface through a listener handoff window.
+ * Pre-connect failures reject with UdsPeerConnectionError.
+ * This only opens the transport; callers still own any capability handshake.
  */
 export function connectToPeer(
   socketPath: string,
+  onSocketError: (error: Error) => void,
   timeoutMs = 5000,
 ): Promise<Socket> {
   return new Promise<Socket>((resolve, reject) => {
     const conn = createConnection(socketPath)
     let settled = false
-    const fail = (cause: unknown) => {
+    const onTimeout = () => {
+      fail(new Error('Connection timed out'))
+    }
+    function cleanupListeners(): void {
+      conn.setTimeout(0)
+      conn.off('error', fail)
+      conn.off('timeout', onTimeout)
+    }
+    function fail(cause: unknown): void {
       if (settled) {
         return
       }
       settled = true
+      cleanupListeners()
       conn.destroy()
       reject(new UdsPeerConnectionError(socketPath, cause))
     }
     conn.once('connect', () => {
+      if (settled) {
+        return
+      }
       settled = true
-      conn.setTimeout(0)
-      conn.off('error', fail)
+      cleanupListeners()
+      conn.on('error', onSocketError)
       resolve(conn)
     })
     conn.on('error', fail)
-    conn.setTimeout(timeoutMs, () => {
-      fail(new Error('Connection timed out'))
-    })
+    conn.once('timeout', onTimeout)
+    conn.setTimeout(timeoutMs)
   })
 }
 


### PR DESCRIPTION
## Summary

Follow-up after #374 was squash-merged before the final review fixes landed.

This PR carries only the final, clean delta on top of current `main`:
- Keep UDS send/connect timeout and socket-error paths on `UdsPeerConnectionError`.
- Hand connected raw sockets back to callers without retaining the internal timeout/error listener.
- Tighten real-path tests for UDS timeout/connect failure, token non-leakage, AgentSummary debug assertions, and platform-specific mailbox directory errno.

## Verification

- `bun test src/utils/__tests__/udsMessaging.test.ts src/services/AgentSummary/__tests__/agentSummary.test.ts src/utils/__tests__/teammateMailbox.test.ts`
- `bunx tsc --noEmit --pretty false`
- `bun run lint`
- `bun run test:all`
- `bun test --coverage --coverage-reporter lcov --coverage-dir coverage`
- `bun run build`
- `bun run build:vite`
- Claude simplify review artifact: `.omx/artifacts/claude-review-only-cross-check-for-pr-374-on-branch-codex-codecov-r-2026-04-27T08-17-47-309Z.md`
- Claude security review artifact: `.omx/artifacts/claude-security-review-cross-check-for-pr-374-current-working-tree--2026-04-27T08-26-54-079Z.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made debug log assertions tolerant (partial matching), added platform-aware errno checks, increased timeout values, and broadened failure/connection coverage for local peer messaging.

* **Refactor**
  * Made peer-connection timeout configurable and hardened connection/error handling so callers retain control of established sockets and post-connect error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->