### PR TITLE
fix: 在模型选择器中 1M 上下文关闭状态也显示 Space to toggle 提示

### DIFF
--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -279,6 +279,7 @@ export function ModelPicker({
             <Text color="subtle">
               <EffortLevelIndicator effort={undefined} /> 1M context off
               {focusedModelName ? ` for ${focusedModelName}` : ''}
+              <Text color="subtle"> · Space to toggle</Text>
             </Text>
           )}
         </Box>


### PR DESCRIPTION
## 问题

在 `/model` 模型选择器中，当用户选中的模型支持 1M 上下文时，UI 会显示一个 1M 上下文的开关状态。开关通过按空格键 (Space) 切换。

然而，之前的代码**只在 1M 开启时**才显示 `· Space to toggle` 操作提示，**关闭时没有**任何提示：

```
○ 1M context off for Opus 4.6
```

用户看到这个界面时，完全不知道按空格键可以切换 1M 上下文的状态。

## 修复

在 1M 关闭状态的提示行中，也加上 `· Space to toggle` 提示，与开启状态的 UI 保持一致：

```
○ 1M context off for Opus 4.6 · Space to toggle
```

## 改动

`src/components/ModelPicker.tsx` — 在 1M 关闭状态的分支中增加一行 `<Text color="subtle"> · Space to toggle</Text>`

## 测试

- `bun run typecheck` 通过，零错误
- 手动验证：进入 `/model` 菜单，选中 Opus/Sonnet 等支持 1M 的模型，确认 1M 关闭/开启两种状态下都能看到 Space to toggle 提示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UI inconsistency: The "Space to toggle" keyboard shortcut hint now appears consistently across all context settings states, helping users discover the keyboard option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->