### PR TITLE
chore: fix biome lint issues (Phase 1)

### DIFF
--- a/packages/builtin-tools/src/tools/BashTool/BashTool.tsx
+++ b/packages/builtin-tools/src/tools/BashTool/BashTool.tsx
@@ -1140,7 +1140,7 @@ async function* runShellCommand({
   let lastProgressOutput = ''
   let lastTotalLines = 0
   let lastTotalBytes = 0
-  let backgroundShellId: string | undefined = undefined
+  let backgroundShellId: string | undefined 
   let assistantAutoBackgrounded = false
 
   // Progress signal: resolved by onProgress callback from the shared poller,
@@ -1314,7 +1314,7 @@ async function* runShellCommand({
 
   // Wait for the initial threshold before showing progress
   const startTime = Date.now()
-  let foregroundTaskId: string | undefined = undefined
+  let foregroundTaskId: string | undefined 
 
   {
     const initialResult = await Promise.race([

--- a/packages/builtin-tools/src/tools/BashTool/bashSecurity.ts
+++ b/packages/builtin-tools/src/tools/BashTool/bashSecurity.ts
@@ -26,6 +26,7 @@ const COMMAND_SUBSTITUTION_PATTERNS = [
     message: 'Zsh equals expansion (=cmd)',
   },
   { pattern: /\$\(/, message: '$() command substitution' },
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: literal string, not a template placeholder
   { pattern: /\$\{/, message: '${} parameter substitution' },
   { pattern: /\$\[/, message: '$[] legacy arithmetic expansion' },
   { pattern: /~\[/, message: 'Zsh-style parameter expansion' },
@@ -1574,7 +1575,6 @@ function hasBackslashEscapedWhitespace(command: string): boolean {
 
     if (char === "'" && !inDoubleQuote) {
       inSingleQuote = !inSingleQuote
-      continue
     }
   }
 
@@ -1687,7 +1687,6 @@ function hasBackslashEscapedOperator(command: string): boolean {
     }
     if (char === '"' && !inSingleQuote) {
       inDoubleQuote = !inDoubleQuote
-      continue
     }
   }
 
@@ -2288,7 +2287,7 @@ function validateNetworkDeviceRedirect(
 // validators. Bash silently drops null bytes and ignores most control chars,
 // so an attacker can use them to slip metacharacters past our checks while
 // bash still executes them (e.g., "echo safe\x00; rm -rf /").
-// eslint-disable-next-line no-control-regex
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally detecting control chars for bash security
 const CONTROL_CHAR_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/
 
 /**

--- a/packages/builtin-tools/src/tools/BashTool/sedValidation.ts
+++ b/packages/builtin-tools/src/tools/BashTool/sedValidation.ts
@@ -480,7 +480,7 @@ function containsDangerousOperations(expression: string): boolean {
   // Reject non-ASCII characters (Unicode homoglyphs, combining chars, etc.)
   // Examples: ｗ (fullwidth), ᴡ (small capital), w̃ (combining tilde)
   // Check for characters outside ASCII range (0x01-0x7F, excluding null byte)
-  // eslint-disable-next-line no-control-regex
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally detecting control chars in sed validation
   if (/[^\x01-\x7F]/.test(cmd)) {
     return true
   }

--- a/packages/builtin-tools/src/tools/FileReadTool/imageProcessor.ts
+++ b/packages/builtin-tools/src/tools/FileReadTool/imageProcessor.ts
@@ -49,7 +49,6 @@ export async function getImageProcessor(): Promise<SharpFunction> {
       return sharpFn
     } catch {
       // Fall back to sharp if native module is not available
-      // biome-ignore lint/suspicious/noConsole: intentional warning
       console.warn(
         'Native image processor not available, falling back to sharp',
       )

--- a/packages/builtin-tools/src/tools/NotebookEditTool/NotebookEditTool.ts
+++ b/packages/builtin-tools/src/tools/NotebookEditTool/NotebookEditTool.ts
@@ -377,7 +377,7 @@ export const NotebookEditTool = buildTool({
       }
 
       const language = notebook.metadata.language_info?.name ?? 'python'
-      let new_cell_id = undefined
+      let new_cell_id 
       if (
         notebook.nbformat > 4 ||
         (notebook.nbformat === 4 && notebook.nbformat_minor >= 5)

--- a/packages/builtin-tools/src/tools/PowerShellTool/PowerShellTool.tsx
+++ b/packages/builtin-tools/src/tools/PowerShellTool/PowerShellTool.tsx
@@ -908,7 +908,7 @@ async function* runPowerShellCommand({
   let lastProgressOutput = ''
   let lastTotalLines = 0
   let lastTotalBytes = 0
-  let backgroundShellId: string | undefined = undefined
+  let backgroundShellId: string | undefined 
   let interruptBackgroundingStarted = false
   let assistantAutoBackgrounded = false
 
@@ -1109,7 +1109,7 @@ async function* runPowerShellCommand({
   // Set up progress yielding with periodic checks
   const startTime = Date.now()
   let nextProgressTime = startTime + PROGRESS_THRESHOLD_MS
-  let foregroundTaskId: string | undefined = undefined
+  let foregroundTaskId: string | undefined 
 
   // Progress loop: wrap in try/finally so stopPolling is called on every exit
   // path — normal completion, timeout/interrupt backgrounding, and Ctrl+B

--- a/packages/builtin-tools/src/tools/WebSearchTool/adapters/exaAdapter.ts
+++ b/packages/builtin-tools/src/tools/WebSearchTool/adapters/exaAdapter.ts
@@ -173,7 +173,7 @@ export class ExaSearchAdapter implements WebSearchAdapter {
 
     // Fallback: markdown links
     if (results.length === 0) {
-      const markdownLinkRegex = /\[([^\]]+)\]\((https?:\/\/[^\)]+)\)/g
+      const markdownLinkRegex = /\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g
       let match: RegExpExecArray | null
       while ((match = markdownLinkRegex.exec(text)) !== null) {
         results.push({

--- a/packages/color-diff-napi/src/__tests__/color-diff.test.ts
+++ b/packages/color-diff-napi/src/__tests__/color-diff.test.ts
@@ -54,6 +54,7 @@ describe("colorToEscape", () => {
 	test("color256 uses 256-color escape", () => {
 		const color = { r: 100, g: 150, b: 200, a: 255 };
 		const result = colorToEscape(color, true, "color256");
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: testing ANSI escape code output
 		expect(result).toMatch(/^\x1b\[38;5;\d+m$/);
 	});
 });

--- a/packages/mcp-client/src/sanitization.ts
+++ b/packages/mcp-client/src/sanitization.ts
@@ -8,8 +8,8 @@
 export function recursivelySanitizeUnicode<T>(data: T): T {
   if (typeof data === 'string') {
     // Remove control characters except \t, \n, \r
-    // Replace null bytes and other C0 controls
     return data
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally stripping control chars for safety
       .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
       .replace(/\uFFFD/g, '') // replacement character
       .normalize('NFC') as unknown as T

--- a/packages/remote-control-server/src/__tests__/sse-writer.test.ts
+++ b/packages/remote-control-server/src/__tests__/sse-writer.test.ts
@@ -120,7 +120,7 @@ describe("SSE Writer", () => {
 
       app.get("/stream/:sessionId", (c) => {
         const sessionId = c.req.param("sessionId");
-        const fromSeq = parseInt(c.req.query("fromSeq") || "0");
+        const fromSeq = parseInt(c.req.query("fromSeq") || "0", 10);
         return createSSEStream(c, sessionId, fromSeq);
       });
 

--- a/packages/remote-control-server/src/config.ts
+++ b/packages/remote-control-server/src/config.ts
@@ -1,13 +1,13 @@
 export const config = {
   version: process.env.RCS_VERSION || "0.1.0",
-  port: parseInt(process.env.RCS_PORT || "3000"),
+  port: parseInt(process.env.RCS_PORT || "3000", 10),
   host: process.env.RCS_HOST || "0.0.0.0",
   apiKeys: (process.env.RCS_API_KEYS || "").split(",").filter(Boolean),
   baseUrl: process.env.RCS_BASE_URL || "",
-  pollTimeout: parseInt(process.env.RCS_POLL_TIMEOUT || "8"),
-  heartbeatInterval: parseInt(process.env.RCS_HEARTBEAT_INTERVAL || "20"),
-  jwtExpiresIn: parseInt(process.env.RCS_JWT_EXPIRES_IN || "3600"),
-  disconnectTimeout: parseInt(process.env.RCS_DISCONNECT_TIMEOUT || "300"),
+  pollTimeout: parseInt(process.env.RCS_POLL_TIMEOUT || "8", 10),
+  heartbeatInterval: parseInt(process.env.RCS_HEARTBEAT_INTERVAL || "20", 10),
+  jwtExpiresIn: parseInt(process.env.RCS_JWT_EXPIRES_IN || "3600", 10),
+  disconnectTimeout: parseInt(process.env.RCS_DISCONNECT_TIMEOUT || "300", 10),
   webCorsOrigins: (process.env.RCS_WEB_CORS_ORIGINS || "")
     .split(",")
     .map((origin) => origin.trim())
@@ -15,10 +15,10 @@ export const config = {
   /** Bun WebSocket idle timeout (seconds). Bun sends protocol-level pings after
    *  this many seconds of no received data. Must be shorter than any reverse
    *  proxy's idle timeout (nginx default 60s, Cloudflare 100s). Default 30s. */
-  wsIdleTimeout: parseInt(process.env.RCS_WS_IDLE_TIMEOUT || "30"),
+  wsIdleTimeout: parseInt(process.env.RCS_WS_IDLE_TIMEOUT || "30", 10),
   /** Server→client keep_alive data-frame interval (seconds). Keeps reverse
    *  proxies from closing idle connections. Default 20s. */
-  wsKeepaliveInterval: parseInt(process.env.RCS_WS_KEEPALIVE_INTERVAL || "20"),
+  wsKeepaliveInterval: parseInt(process.env.RCS_WS_KEEPALIVE_INTERVAL || "20", 10),
 } as const;
 
 export function getBaseUrl(): string {

--- a/packages/remote-control-server/src/routes/v2/worker-events-stream.ts
+++ b/packages/remote-control-server/src/routes/v2/worker-events-stream.ts
@@ -16,7 +16,7 @@ app.get("/:id/worker/events/stream", acceptCliHeaders, sessionIngressAuth, async
   // Support Last-Event-ID / from_sequence_num for reconnection
   const lastEventId = c.req.header("Last-Event-ID");
   const fromSeq = c.req.query("from_sequence_num");
-  const fromSeqNum = fromSeq ? parseInt(fromSeq) : lastEventId ? parseInt(lastEventId) : 0;
+  const fromSeqNum = fromSeq ? parseInt(fromSeq, 10) : lastEventId ? parseInt(lastEventId, 10) : 0;
 
   return createWorkerEventStream(c, sessionId, fromSeqNum);
 });

--- a/packages/remote-control-server/src/routes/web/sessions.ts
+++ b/packages/remote-control-server/src/routes/web/sessions.ts
@@ -111,7 +111,7 @@ app.get("/sessions/:id/events", uuidAuth, async (c) => {
   }
 
   const lastEventId = c.req.header("Last-Event-ID");
-  const fromSeqNum = lastEventId ? parseInt(lastEventId) : 0;
+  const fromSeqNum = lastEventId ? parseInt(lastEventId, 10) : 0;
   return createSSEStream(c, sessionId, fromSeqNum);
 });
 

--- a/packages/remote-control-server/src/services/automationState.ts
+++ b/packages/remote-control-server/src/services/automationState.ts
@@ -29,7 +29,7 @@ function readAutomationStateValue(metadata: Record<string, unknown> | null | und
   if (!metadata || typeof metadata !== "object") {
     return undefined;
   }
-  if (!Object.prototype.hasOwnProperty.call(metadata, "automation_state")) {
+  if (!Object.hasOwn(metadata, "automation_state")) {
     return undefined;
   }
   return metadata.automation_state;

--- a/packages/remote-control-server/web/src/acp/client.ts
+++ b/packages/remote-control-server/web/src/acp/client.ts
@@ -71,6 +71,7 @@ export class ACPClient {
   private settings: ACPSettings;
   private connectionState: ConnectionState = "disconnected";
   private sessionId: string | null = null;
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: used for write-only session target tracking
   private pendingSessionTarget: string | null = null;
   // Reference: Zed stores full agentCapabilities from initialize response
   // Used to check supports_load_session, supports_resume_session, etc.
@@ -100,6 +101,7 @@ export class ACPClient {
   private pendingSessionLoad: { resolve: (sessionId: string) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> } | null = null;
   private pendingSessionResume: { resolve: (sessionId: string) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> } | null = null;
 
+  // biome-ignore lint/suspicious/noConfusingVoidType: void is correct for resolve() with no args
   private connectResolve: ((value: void) => void) | null = null;
   private connectReject: ((error: Error) => void) | null = null;
 

--- a/packages/remote-control-server/web/src/components/EventStream.tsx
+++ b/packages/remote-control-server/web/src/components/EventStream.tsx
@@ -788,7 +788,7 @@ function LoadingIndicator({ verb }: { verb: string }) {
 // Event Processing Hook
 // ============================================================
 
-export { type DisplayMessage, type TraceEntry, type UserMessage, type AssistantMessage, type SystemMessage, type PermissionMessage, type AskUserMessage, type PlanMessage, type LoadingMessage };
+export type { DisplayMessage, TraceEntry, UserMessage, AssistantMessage, SystemMessage, PermissionMessage, AskUserMessage, PlanMessage, LoadingMessage };
 
 export function useEventProcessor() {
   const [messages, setMessages] = useState<DisplayMessage[]>([]);


### PR DESCRIPTION
## Summary

Part of #345 — biome lint 规范化第一阶段。

### Changes

| Fix Type | Count | Method |
|----------|-------|--------|
| `useParseIntRadix` | 11 | Add radix parameter `10` |
| `noUselessUndefinedInitialization` | 5 | Remove `= undefined` |
| `noUselessContinue` | 2 | Remove unnecessary `continue` |
| `noControlCharactersInRegex` | 3 files | Add `biome-ignore` (intentional usage) |
| `noPrototypeBuiltins` | 1 | `Object.prototype.hasOwnProperty` → `Object.hasOwn` |
| `useExportType` | 1 | Add `type` keyword |
| `noUselessEscapeInRegex` | 1 | Remove unnecessary escape |
| `noTemplateCurlyInString` | 1 | Add `biome-ignore` (literal string) |
| Ineffective suppression | 1 | Remove dead `biome-ignore` comment |

### Results

- **Lint errors: 19 → 7** (63% reduction)
- **TypeScript compilation: ✅ Pass** (`tsc --noEmit` clean)
- **16 files changed, net 1 line addition**

### Not in scope (separate PRs)

- `noDangerouslySetInnerHtml` × 3 — requires sanitizer refactor
- `noAsyncPromiseExecutor` × 1 — requires Promise restructuring  
- `noImportantStyles` × 3 — CSS `!important` intentionally used for reduce-motion

### Test

```bash
bun run typecheck  # ✅ pass
npx biome lint     # 7 remaining (out of scope)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary code patterns and updated to modern syntax conventions for improved maintainability.
  * Enhanced consistency in numeric parsing across server components with explicit base-10 conversion.

* **Bug Fixes**
  * Corrected web search URL extraction for markdown-formatted links to prevent incomplete URL capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->