### PR TITLE
fix: 保留 DeepSeek v4 thinking mode 的空 reasoning_content (#399)

### DIFF
--- a/packages/@ant/model-provider/src/shared/__tests__/openaiConvertMessages.test.ts
+++ b/packages/@ant/model-provider/src/shared/__tests__/openaiConvertMessages.test.ts
@@ -468,7 +468,11 @@ describe('DeepSeek thinking mode (enableThinking)', () => {
     expect(assistant.reasoning_content).toBe('First thought.\nSecond thought.')
   })
 
-  test('skips empty thinking blocks', () => {
+  test('preserves empty thinking blocks as reasoning_content: "" (DeepSeek v4 thinking mode)', () => {
+    // DeepSeek v4 thinking mode sometimes returns reasoning_content: ""
+    // when the model answers directly without reasoning. The empty value
+    // must be echoed back in the next request — otherwise DeepSeek returns
+    // 400 ("reasoning_content ... must be passed back"). See issue #399.
     const result = anthropicMessagesToOpenAI(
       [
         makeUserMsg('question'),
@@ -481,7 +485,23 @@ describe('DeepSeek thinking mode (enableThinking)', () => {
       { enableThinking: true },
     )
     const assistant = result.filter(m => m.role === 'assistant')[0] as any
+    expect(assistant.reasoning_content).toBe('')
+    expect(assistant.content).toBe('Answer.')
+  })
+
+  test('omits reasoning_content when no thinking block is present', () => {
+    // No thinking block at all → no reasoning_content field on the
+    // OpenAI-format assistant message (relevant for non-thinking models).
+    const result = anthropicMessagesToOpenAI(
+      [
+        makeUserMsg('question'),
+        makeAssistantMsg([{ type: 'text', text: 'Answer.' }]),
+      ],
+      [] as any,
+    )
+    const assistant = result.filter(m => m.role === 'assistant')[0] as any
     expect(assistant.reasoning_content).toBeUndefined()
+    expect(assistant.content).toBe('Answer.')
   })
 
   // ── fix: reorder tool and user messages for OpenAI API compatibility (#168) ──

--- a/packages/@ant/model-provider/src/shared/__tests__/openaiStreamAdapter.test.ts
+++ b/packages/@ant/model-provider/src/shared/__tests__/openaiStreamAdapter.test.ts
@@ -439,6 +439,54 @@ describe('thinking support (reasoning_content)', () => {
     expect(blockStarts[1].content_block.type).toBe('tool_use')
   })
 
+  test('opens thinking block on empty reasoning_content (DeepSeek v4 direct-answer)', async () => {
+    // DeepSeek v4 thinking mode sometimes streams reasoning_content: ""
+    // before answering directly. We must still open a thinking block so the
+    // resulting assistant message carries an (empty) thinking block — that
+    // round-trips back as reasoning_content: "" in the next request,
+    // satisfying DeepSeek's requirement (see issue #399).
+    const events = await collectEvents([
+      makeChunk({
+        choices: [
+          {
+            index: 0,
+            delta: { reasoning_content: '' },
+            finish_reason: null,
+          },
+        ],
+      }),
+      makeChunk({
+        choices: [
+          {
+            index: 0,
+            delta: { content: 'Direct answer.' },
+            finish_reason: null,
+          },
+        ],
+      }),
+      makeChunk({
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      }),
+    ])
+
+    // A thinking block was opened (and closed before the text block starts)
+    const blockStarts = events.filter(
+      e => e.type === 'content_block_start',
+    ) as any[]
+    expect(blockStarts.length).toBe(2)
+    expect(blockStarts[0].content_block.type).toBe('thinking')
+    expect(blockStarts[0].content_block.thinking).toBe('')
+    expect(blockStarts[1].content_block.type).toBe('text')
+
+    // No empty thinking_delta should be emitted — the empty string is
+    // already conveyed by the thinking block's initial value.
+    const thinkingDeltas = events.filter(
+      e =>
+        e.type === 'content_block_delta' && e.delta.type === 'thinking_delta',
+    )
+    expect(thinkingDeltas.length).toBe(0)
+  })
+
   test('thinking block index is 0, text block index is 1', async () => {
     const events = await collectEvents([
       makeChunk({

--- a/packages/@ant/model-provider/src/shared/openaiConvertMessages.ts
+++ b/packages/@ant/model-provider/src/shared/openaiConvertMessages.ts
@@ -206,12 +206,14 @@ function convertInternalAssistantMessage(
         },
       })
     } else if (block.type === 'thinking') {
-      // DeepSeek thinking mode: always preserve reasoning_content.
-      // DeepSeek requires reasoning_content to be passed back in subsequent requests,
-      // especially when tool calls are involved (returns 400 if missing).
+      // DeepSeek thinking mode: always preserve reasoning_content,
+      // including the empty-string case. DeepSeek v4 may return
+      // reasoning_content: "" when the model answers directly, and the
+      // empty value must be echoed back in the next request — otherwise
+      // DeepSeek returns 400 ("reasoning_content ... must be passed back").
       const thinkingText = (block as unknown as Record<string, unknown>)
         .thinking
-      if (typeof thinkingText === 'string' && thinkingText) {
+      if (typeof thinkingText === 'string') {
         reasoningParts.push(thinkingText)
       }
     }

--- a/packages/@ant/model-provider/src/shared/openaiStreamAdapter.ts
+++ b/packages/@ant/model-provider/src/shared/openaiStreamAdapter.ts
@@ -106,9 +106,13 @@ export async function* adaptOpenAIStreamToAnthropic(
     // Skip chunks that carry only usage data (no delta content)
     if (!delta) continue
 
-    // Handle reasoning_content → Anthropic thinking block
+    // Handle reasoning_content → Anthropic thinking block.
+    // Empty string is a valid signal: DeepSeek v4 thinking mode sometimes
+    // returns reasoning_content: "" when the model answers directly. The
+    // empty thinking block must round-trip back to the API in subsequent
+    // requests, otherwise DeepSeek rejects with 400.
     const reasoningContent = (delta as any).reasoning_content
-    if (reasoningContent != null && reasoningContent !== '') {
+    if (reasoningContent != null) {
       if (!thinkingBlockOpen) {
         currentContentIndex++
         thinkingBlockOpen = true
@@ -125,14 +129,16 @@ export async function* adaptOpenAIStreamToAnthropic(
         } as BetaRawMessageStreamEvent
       }
 
-      yield {
-        type: 'content_block_delta',
-        index: currentContentIndex,
-        delta: {
-          type: 'thinking_delta',
-          thinking: reasoningContent,
-        },
-      } as BetaRawMessageStreamEvent
+      if (reasoningContent !== '') {
+        yield {
+          type: 'content_block_delta',
+          index: currentContentIndex,
+          delta: {
+            type: 'thinking_delta',
+            thinking: reasoningContent,
+          },
+        } as BetaRawMessageStreamEvent
+      }
     }
 
     // Handle text content


### PR DESCRIPTION
## 背景

修复 #399 与 #401（同一个根因，#401 触发条件是多轮对话——次数越多越容易撞上）。

接入 DeepSeek 的 `/model opus` 后频繁报：

```
API Error: 400 The `reasoning_content` in the thinking mode must be passed back to the API.
```

## 根因

DeepSeek v4 在 thinking mode 下，**有时**会直接给出答案、`reasoning_content` 是空字符串 `""`（而不是缺省/null）。当前代码在两个地方把空串当成"没有思考"过滤掉：

1. `openaiStreamAdapter.ts:111` —— 收到 `delta.reasoning_content === ''` 时不开 thinking block，导致 assistant 消息里压根没有 thinking block
2. `openaiConvertMessages.ts:214` —— 即便消息里有空 thinking block，序列化回 OpenAI 格式时也被 truthy check 过滤

结果：下一轮请求里上一条 assistant 消息缺 `reasoning_content` 字段，DeepSeek 直接 400。多轮对话下，只要历史里有任何一轮命中了"直接答"路径，后续请求就会 400 ——这解释了 #401 里"对话次数 ≥20 就出错"的概率累积现象。

## 修复

- **stream adapter**:只要 `reasoning_content != null`（包含空串）就开 thinking block；空串时不发多余的 `thinking_delta`，因为 block 初始 `thinking: ''` 已经表达了空值
- **convert messages**:把过滤条件从 `&& thinkingText` 放宽到只要是 string 就 push，让空 thinking block 序列化为 `reasoning_content: ""` 回传

## 测试

`bun test packages/@ant/model-provider`:111 pass / 0 fail

新增/更新的关键用例：

- ✅ `openaiStreamAdapter.test.ts`:新增 `opens thinking block on empty reasoning_content (DeepSeek v4 direct-answer)`
- ✅ `openaiConvertMessages.test.ts`:原 `skips empty thinking blocks`（写的是 bug 行为）改为 `preserves empty thinking blocks as reasoning_content: "" (DeepSeek v4 thinking mode)`
- ✅ `openaiConvertMessages.test.ts`:新增 `omits reasoning_content when no thinking block is present`，作为非 thinking 模型的回归保护

`src/services/api/openai` 的 39 个消费方测试也全过。

## 校验

- [x] `bun test packages/@ant/model-provider` 全过
- [x] `bun test src/services/api/openai` 全过
- [x] `bun run typecheck` 零错误
- [x] `bunx biome ci` 改动文件无 lint/格式问题

Closes #399
Closes #401