### PR TITLE
fix: third-party API user_id validation error (DeepSeek, etc.)

### DIFF
--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -509,10 +509,30 @@ export function getAPIMetadata() {
     }
   }
 
+  const deviceId = getOrCreateUserID()
+
+  // Third-party API providers (DeepSeek, etc.) validate user_id against
+  // ^[a-zA-Z0-9_-]+$ which rejects JSON strings containing {, ", :, etc.
+  // When using a non-Anthropic base URL, send only the device_id (hex string).
+  const baseUrl = process.env.ANTHROPIC_BASE_URL
+  const isThirdParty =
+    baseUrl &&
+    (() => {
+      try {
+        return new URL(baseUrl).host !== 'api.anthropic.com'
+      } catch {
+        return false
+      }
+    })()
+
+  if (isThirdParty) {
+    return { user_id: deviceId }
+  }
+
   return {
     user_id: jsonStringify({
       ...extra,
-      device_id: getOrCreateUserID(),
+      device_id: deviceId,
       // Only include OAuth account UUID when actively using OAuth authentication
       account_uuid: getOauthAccountInfo()?.accountUuid ?? '',
       session_id: getSessionId(),


### PR DESCRIPTION
When ANTHROPIC_BASE_URL points to a non-Anthropic endpoint (e.g. DeepSeek), the JSON-formatted user_id containing {, ", : characters fails validation against ^[a-zA-Z0-9_-]+$. Send only the hex device_id for third-party providers.  就是跳过用户id的输入。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/claude-code-best/codesmith/claude-code/pr/420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized API metadata assembly logic to conditionally structure payload information based on usage context, improving efficiency without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->