### PR TITLE
fix: modify deepseek's context to 1m

### DIFF
--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -99,6 +99,11 @@ export function getContextWindowForModel(
       return antModel.contextWindow
     }
   }
+
+  if (model.toLowerCase().includes('deepseek-v4')) {
+    return 1_000_000
+  }
+
   return MODEL_CONTEXT_WINDOW_DEFAULT
 }
 

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -100,8 +100,12 @@ export function getContextWindowForModel(
     }
   }
 
-  // Models that natively support 1M context window
-  if (/deepseek-v4|gpt-5\.[45]/.test(model.toLowerCase())) {
+  const lower = model.toLowerCase()
+  if (
+    lower.includes('deepseek-v4') ||
+    lower.includes('gpt-5.4') ||
+    lower.includes('gpt-5.5')
+  ) {
     return 1_000_000
   }
 

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -100,7 +100,8 @@ export function getContextWindowForModel(
     }
   }
 
-  if (model.toLowerCase().includes('deepseek-v4')) {
+  // Models that natively support 1M context window
+  if (/deepseek-v4|gpt-5\.[45]/.test(model.toLowerCase())) {
     return 1_000_000
   }
 


### PR DESCRIPTION
小修改，增加了对 deepseek-v4 的特判，context 正确显示为 1m，原本会 fallback 到 200k
<img width="719" height="390" alt="image" src="https://github.com/user-attachments/assets/6f1fef7b-b79e-4b3d-b005-e7dae33a9ebb" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/claude-code-best/codesmith/claude-code/pr/431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the deepseek-v4 model with a 1,000,000‑token context window. Users of that model can now work with substantially larger inputs and conversations without changing existing public interfaces. No public API or type signatures were altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->