### PR TITLE
fix(acp): 对齐 ACP session ID 与全局会话状态

### DIFF
--- a/src/services/acp/__tests__/agent.test.ts
+++ b/src/services/acp/__tests__/agent.test.ts
@@ -69,8 +69,11 @@ mockModulePreservingExports('../../../utils/config.ts', {
   enableConfigs: mock(() => {}),
 })
 
+const mockSwitchSession = mock(() => {})
+
 mockModulePreservingExports('../../../bootstrap/state.ts', {
   setOriginalCwd: mock(() => {}),
+  switchSession: mockSwitchSession,
   addSlowOperation: mock(() => {}),
 })
 
@@ -222,6 +225,7 @@ describe('AcpAgent', () => {
     delete process.env.ACP_PERMISSION_MODE
     delete process.env.CLAUDE_CODE_ACP_ALLOW_BYPASS_PERMISSIONS
     mockSetModel.mockClear()
+    mockSwitchSession.mockClear()
     mockSubmitMessage.mockReset()
     mockSubmitMessage.mockImplementation(async function* (_input: string) {})
     mockGetMainLoopModel.mockClear()
@@ -1155,6 +1159,68 @@ describe('AcpAgent', () => {
         (c: any) => c.name === 'commit',
       )
       expect(commit.input).toEqual({ hint: '[message]' })
+    })
+  })
+
+  describe('sessionId alignment with global state', () => {
+    test('newSession calls switchSession with the generated sessionId', async () => {
+      const agent = new AcpAgent(makeConn())
+      const res = await agent.newSession({ cwd: '/tmp' } as any)
+      expect(mockSwitchSession).toHaveBeenCalledWith(res.sessionId)
+    })
+
+    test('resumeSession calls switchSession with the requested sessionId', async () => {
+      const agent = new AcpAgent(makeConn())
+      const requestedId = 'resume-test-session-id'
+      await agent.unstable_resumeSession({
+        sessionId: requestedId,
+        cwd: '/tmp',
+        mcpServers: [],
+      } as any)
+
+      expect(mockSwitchSession).toHaveBeenCalledWith(requestedId)
+    })
+
+    test('loadSession calls switchSession with the requested sessionId', async () => {
+      const agent = new AcpAgent(makeConn())
+      const requestedId = 'load-test-session-id'
+      await agent.loadSession({
+        sessionId: requestedId,
+        cwd: '/tmp',
+        mcpServers: [],
+      } as any)
+
+      expect(mockSwitchSession).toHaveBeenCalledWith(requestedId)
+    })
+
+    test('resumeSession with existing session still calls switchSession', async () => {
+      const agent = new AcpAgent(makeConn())
+      const { sessionId } = await agent.newSession({ cwd: '/tmp' } as any)
+      mockSwitchSession.mockClear()
+
+      // Resume the same session — should still align global state
+      await agent.unstable_resumeSession({
+        sessionId,
+        cwd: '/tmp',
+        mcpServers: [],
+      } as any)
+
+      expect(mockSwitchSession).toHaveBeenCalledWith(sessionId)
+    })
+
+    test('prompt does not trigger additional switchSession for multi-session', async () => {
+      const agent = new AcpAgent(makeConn())
+      await agent.newSession({ cwd: '/tmp' } as any)
+      await agent.newSession({ cwd: '/tmp' } as any)
+      mockSwitchSession.mockClear()
+
+      // Prompts should not call switchSession — alignment happens at session creation
+      const s1 = agent.sessions.keys().next().value
+      await agent.prompt({
+        sessionId: s1,
+        prompt: [{ type: 'text', text: 'hello' }],
+      } as any)
+      expect(mockSwitchSession).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/services/acp/agent.ts
+++ b/src/services/acp/agent.ts
@@ -53,7 +53,8 @@ import { getEmptyToolPermissionContext } from '../../Tool.js'
 import type { PermissionMode } from '../../types/permissions.js'
 import type { Command } from '../../types/command.js'
 import { getCommands } from '../../commands.js'
-import { setOriginalCwd } from '../../bootstrap/state.js'
+import { setOriginalCwd, switchSession } from '../../bootstrap/state.js'
+import type { SessionId } from '../../types/ids.js'
 import { enableConfigs } from '../../utils/config.js'
 import { FileStateCache } from '../../utils/fileStateCache.js'
 import { getDefaultAppState } from '../../state/AppStateStore.js'
@@ -471,6 +472,10 @@ export class AcpAgent implements Agent {
     const sessionId = opts.sessionId ?? randomUUID()
     const cwd = params.cwd
 
+    // Align the global session state so that transcript persistence,
+    // analytics, and cost tracking use the ACP session ID.
+    switchSession(sessionId as SessionId)
+
     // Set CWD for the session
     setOriginalCwd(cwd)
     const previousProcessCwd = process.cwd()
@@ -675,6 +680,8 @@ export class AcpAgent implements Agent {
           | undefined,
       })
       if (fingerprint === existingSession.sessionFingerprint) {
+        // Align global state so subsequent operations use the correct session
+        switchSession(params.sessionId as SessionId)
         return {
           sessionId: params.sessionId,
           modes: existingSession.modes,
@@ -686,6 +693,10 @@ export class AcpAgent implements Agent {
       // Session-defining params changed — tear down and recreate
       await this.teardownSession(params.sessionId)
     }
+
+    // Align global state BEFORE sessionIdExists() check — the lookup uses
+    // getSessionId() internally when resolving project-scoped paths.
+    switchSession(params.sessionId as SessionId)
 
     // Set CWD early so session file lookup can find the right project directory
     setOriginalCwd(params.cwd)


### PR DESCRIPTION
问题描述：
使用--acp启动后，使用newSession协议返回的sessionId和Claude Code本身的sessionId不一致，导致后续对话通过该返回的sessionId对话都是全新会话，无法继续之前会话。

解决方案：
在 newSession/resumeSession/loadSession 中调用 switchSession， 确保 transcript 持久化、analytics 与 cost tracking 使用 ACP session ID， 而非内部默认 session ID。

- newSession 生成 sessionId 后立即对齐全局状态，确保Claude Code sessionId与ACP返回的sesssionId一致
- resumeSession 命中 fingerprint 缓存路径也对齐
- loadSession 在 sessionIdExists() 检查前对齐（lookup 依赖 getSessionId）
- 补充 5 个测试覆盖上述路径，以及 prompt 不触发额外 switchSession

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/claude-code-best/codesmith/claude-code/pr/1117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite validating session ID alignment with application state across session creation, resuming, and loading operations.

* **Bug Fixes**
  * Enhanced session state synchronization to ensure the global state properly reflects the active session across all operations, preventing state inconsistencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/claude-code-best/claude-code/pull/1117)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->