### PR TITLE
fix: 修复子代理 token 显示为 0 + cacheWarningStateBySource Map 内存泄漏

### DIFF
--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -23,6 +23,7 @@ import { getDefaultCharacters, type SpinnerMode } from './Spinner/index.js';
 import { SpinnerAnimationRow } from './Spinner/SpinnerAnimationRow.js';
 import { useSettings } from '../hooks/useSettings.js';
 import { isInProcessTeammateTask } from '../tasks/InProcessTeammateTask/types.js';
+import { isLocalAgentTask } from '../tasks/LocalAgentTask/LocalAgentTask.js';
 import { isBackgroundTask } from '../tasks/types.js';
 import { getAllInProcessTeammateTasks } from '../tasks/InProcessTeammateTask/InProcessTeammateTask.js';
 import { getEffortSuffix } from '../utils/effort.js';
@@ -214,7 +215,7 @@ function SpinnerWithVerbInner({
   let teammateTokens = 0;
   if (!showSpinnerTree) {
     for (const task of Object.values(tasks)) {
-      if (isInProcessTeammateTask(task) && task.status === 'running') {
+      if (task.status === 'running' && (isInProcessTeammateTask(task) || isLocalAgentTask(task))) {
         if (task.progress?.tokenCount) {
           teammateTokens += task.progress.tokenCount;
         }

--- a/src/utils/cacheWarning.ts
+++ b/src/utils/cacheWarning.ts
@@ -24,6 +24,12 @@ interface CacheWarningState {
 // 模块级状态，每个 querySource 独立跟踪
 const cacheWarningStateBySource = new Map<string, CacheWarningState>()
 
+// Limit the number of tracked sources to prevent unbounded Map growth.
+// querySource strings are effectively unbounded (typed as `any`), so a
+// long-running session that spawns many subagents could leak memory.
+// Evict the oldest entry (by insertion order) when the limit is exceeded.
+const MAX_SOURCE_ENTRIES = 50
+
 const DEFAULT_CACHE_THRESHOLD = 80
 
 /**
@@ -81,6 +87,13 @@ export function shouldShowCacheWarning(
   let state = cacheWarningStateBySource.get(querySource)
   if (!state) {
     state = { lastHitRate: null, lastTimestamp: null }
+    // Evict oldest entry when at capacity so the Map stays bounded
+    if (cacheWarningStateBySource.size >= MAX_SOURCE_ENTRIES) {
+      const oldestKey = cacheWarningStateBySource.keys().next().value
+      if (oldestKey !== undefined) {
+        cacheWarningStateBySource.delete(oldestKey)
+      }
+    }
     cacheWarningStateBySource.set(querySource, state)
   }
 
@@ -131,4 +144,11 @@ export function createCacheWarningMessage(info: CacheHitRateInfo): Message {
     uuid: randomUUID(),
     isMeta: false,
   } as Message
+}
+
+/**
+ * Reset the per-source tracking state — only used in tests.
+ */
+export function _resetCacheWarningStateForTest(): void {
+  cacheWarningStateBySource.clear()
 }

--- a/src/utils/swarm/inProcessRunner.ts
+++ b/src/utils/swarm/inProcessRunner.ts
@@ -47,6 +47,7 @@ import {
 import type { CustomAgentDefinition } from '@claude-code-best/builtin-tools/tools/AgentTool/loadAgentsDir.js'
 import { runAgent } from '@claude-code-best/builtin-tools/tools/AgentTool/runAgent.js'
 import { awaitClassifierAutoApproval } from '@claude-code-best/builtin-tools/tools/BashTool/bashPermissions.js'
+import type { AgentToolResult } from '@claude-code-best/builtin-tools/tools/AgentTool/agentToolUtils.js'
 import { BASH_TOOL_NAME } from '@claude-code-best/builtin-tools/tools/BashTool/toolName.js'
 import { SEND_MESSAGE_TOOL_NAME } from '@claude-code-best/builtin-tools/tools/SendMessageTool/constants.js'
 import { TASK_CREATE_TOOL_NAME } from '@claude-code-best/builtin-tools/tools/TaskCreateTool/constants.js'
@@ -63,7 +64,10 @@ import {
 } from '../../utils/messages.js'
 import { evictTaskOutput } from '../../utils/task/diskOutput.js'
 import { evictTerminalTask } from '../../utils/task/framework.js'
-import { tokenCountWithEstimation } from '../../utils/tokens.js'
+import {
+  tokenCountWithEstimation,
+  getTokenCountFromUsage,
+} from '../../utils/tokens.js'
 import { createAbortController } from '../abortController.js'
 import { type AgentContext, runWithAgentContext } from '../agentContext.js'
 import {
@@ -915,6 +919,7 @@ export async function runInProcessTeammate(
     invokingRequestId,
   } = config
   const { setAppState } = toolUseContext
+  const startTime = Date.now()
 
   logForDebugging(
     `[inProcessRunner] Starting agent loop for ${identity.agentId}`,
@@ -1463,6 +1468,48 @@ export async function runInProcessTeammate(
     // Mark as completed when exiting the loop
     let alreadyTerminal = false
     let toolUseId: string | undefined
+
+    // Compute result so the detail dialog can show token usage.
+    // Walk backwards for the last API usage (cumulative input_tokens from the
+    // Anthropic API already includes all prior context).
+    let completionTokens = 0
+    let completionToolUseCount = 0
+    let lastAssistantContent: AgentToolResult['content'] = []
+    let lastUsage: AgentToolResult['usage'] | undefined
+    for (let i = allMessages.length - 1; i >= 0; i--) {
+      const m = allMessages[i]!
+      if (m.type === 'assistant') {
+        const blocks = (m.message?.content ?? []) as any[]
+        for (const b of blocks) {
+          if (b?.type === 'tool_use') completionToolUseCount++
+        }
+        const textBlocks = blocks.filter((b: any) => b?.type === 'text')
+        if (textBlocks.length > 0 && lastAssistantContent.length === 0) {
+          lastAssistantContent = textBlocks.map((b: any) => ({
+            type: 'text' as const,
+            text: b.text,
+          }))
+        }
+        if (!lastUsage && m.message?.usage) {
+          lastUsage = m.message.usage as AgentToolResult['usage']
+          completionTokens = getTokenCountFromUsage(
+            m.message.usage as Parameters<typeof getTokenCountFromUsage>[0],
+          )
+        }
+        if (completionTokens > 0 && lastAssistantContent.length > 0) break
+      }
+    }
+
+    const teammateResult: AgentToolResult = {
+      agentId: identity.agentId,
+      agentType: 'teammate',
+      content: lastAssistantContent,
+      totalToolUseCount: completionToolUseCount,
+      totalDurationMs: Date.now() - startTime,
+      totalTokens: completionTokens,
+      usage: lastUsage as AgentToolResult['usage'],
+    } as unknown as AgentToolResult
+
     updateTaskState(
       taskId,
       task => {
@@ -1481,6 +1528,7 @@ export async function runInProcessTeammate(
           status: 'completed' as const,
           notified: true,
           endTime: Date.now(),
+          result: teammateResult,
           messages: task.messages?.length ? [task.messages.at(-1)!] : undefined,
           pendingUserMessages: [],
           inProgressToolUseIDs: undefined,


### PR DESCRIPTION
## Summary

Spinner.tsx 的 token 聚合循环仅统计 in_process_teammate 类型任务，
漏掉了 local_agent（后台代理/verification agent）类型，导致主界面
spinner 在子代理运行时一直显示 "↓ 0 tokens"。

同时在 inProcessRunner.ts 中，进程内队友完成时计算并设置 result
（含 totalTokens/totalToolUseCount），使详情弹窗可以展示 token 消耗。

## Test plan

- [x] tsc --noEmit 零错误
- [x] biome lint 零违规
- [x] biome format 零差异
- [x] bun test 全量 5298 pass（14 fail 均为预存问题）
- [x] swarm + LocalAgentTask 相关测试 29 pass
- [x] component 相关测试 32 pass

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token aggregation to include all teammate task types when computing teammate token totals.
  * Improved task completion recording to capture timing, tool-use counts, and token usage for teammate runs.

* **Chores**
  * Bounded cache-warning tracking to prevent unbounded growth and added a test-only reset for cache warning state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/claude-code-best/claude-code/pull/1225)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->