### PR TITLE
fix: showSpinnerTree 模式下保留 local-agent token 显示

### DIFF
--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -210,15 +210,22 @@ function SpinnerWithVerbInner({
   const hasRunningTeammates = runningTeammates.length > 0;
   const allIdle = hasRunningTeammates && runningTeammates.every(t => t.isIdle);
 
-  // Gather aggregate token stats from all running swarm teammates
-  // In spinner-tree mode, skip aggregation (teammates have their own lines in the tree)
+  // Gather aggregate token stats from all running agents.
+  // In spinner-tree mode, skip in-process teammates (they have their own
+  // per-teammate lines in the tree) but still count local-agent tasks
+  // (background agents) which have no dedicated tree rows.
   let teammateTokens = 0;
-  if (!showSpinnerTree) {
-    for (const task of Object.values(tasks)) {
-      if (task.status === 'running' && (isInProcessTeammateTask(task) || isLocalAgentTask(task))) {
-        if (task.progress?.tokenCount) {
-          teammateTokens += task.progress.tokenCount;
-        }
+  for (const task of Object.values(tasks)) {
+    if (task.status !== 'running') continue;
+    if (isInProcessTeammateTask(task)) {
+      if (!showSpinnerTree && task.progress?.tokenCount) {
+        teammateTokens += task.progress.tokenCount;
+      }
+      continue;
+    }
+    if (isLocalAgentTask(task)) {
+      if (task.progress?.tokenCount) {
+        teammateTokens += task.progress.tokenCount;
       }
     }
   }


### PR DESCRIPTION
## Summary

此修复源自 PR [#1226](https://github.com/claude-code-best/claude-code/pull/1226)
中 CodeRabbit 审查的建议，但实际属于已合并的 PR
[#1225](https://github.com/claude-code-best/claude-code/pull/1225) 的内容。

**问题：** `showSpinnerTree` 模式开启时，整个 token 聚合循环被 `if (!showSpinnerTree)` guard 跳过，导致 `local_agent`（后台代理）的 token 消耗完全不可见——因为只有 `in_process_teammate` 任务在树中有独立行，`local_agent` 没有。

**修复：** 将 guard 从循环外移到循环内：
- `in_process_teammate` 任务在 tree 模式下跳过（它们有独立树行）
- `local_agent` 任务始终计入 `teammateTokens`

## Test plan

- [x] tsc --noEmit 零错误
- [x] biome format 零差异
- [x] biome lint 零违规

## See also

- PR #1226 CodeRabbit review comment (spinner-tree local-agent token visibility)
- PR #1225 (original sub-agent token aggregation fix)

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token count aggregation to properly display across all view modes. Token totals now accurately reflect contributions from all running tasks, including background operations, ensuring consistent visibility regardless of display selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/claude-code-best/claude-code/pull/1228)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->