### PR TITLE
fix: OpenAI 路径添加防御性 usage 合并逻辑

### DIFF
--- a/src/services/api/openai/index.ts
+++ b/src/services/api/openai/index.ts
@@ -131,6 +131,46 @@ function isOpenAIConvertibleMessage(
 }
 
 /**
+ * Merge delta usage into accumulated usage, preserving cache fields from
+ * previous values when the delta carries explicit zeroes.
+ *
+ * Mirrors updateUsage() in claude.ts: Anthropic's streaming API may send
+ * explicit 0 for cache fields in message_delta events, which should not
+ * overwrite valid values from message_start. OpenAI-compatible endpoints
+ * don't currently exhibit this behavior, but defensive field-level merging
+ * prevents a future adapter change from silently zeroing cache data.
+ */
+function updateOpenAIUsage(
+  current: {
+    input_tokens: number
+    output_tokens: number
+    cache_creation_input_tokens: number
+    cache_read_input_tokens: number
+  },
+  delta: {
+    input_tokens?: number
+    output_tokens?: number
+    cache_creation_input_tokens?: number
+    cache_read_input_tokens?: number
+  },
+): typeof current {
+  return {
+    input_tokens: delta.input_tokens ?? current.input_tokens,
+    output_tokens: delta.output_tokens ?? current.output_tokens,
+    cache_creation_input_tokens:
+      delta.cache_creation_input_tokens !== undefined &&
+      delta.cache_creation_input_tokens > 0
+        ? delta.cache_creation_input_tokens
+        : current.cache_creation_input_tokens,
+    cache_read_input_tokens:
+      delta.cache_read_input_tokens !== undefined &&
+      delta.cache_read_input_tokens > 0
+        ? delta.cache_read_input_tokens
+        : current.cache_read_input_tokens,
+  }
+}
+
+/**
  * Assemble the final AssistantMessage (and optional max_tokens error) from
  * accumulated stream state. Extracted to avoid duplication between the
  * `message_stop` handler and the post-loop safety fallback.
@@ -449,7 +489,10 @@ export async function* queryModelOpenAI(
         case 'message_delta': {
           const deltaUsage = (event as any).usage
           if (deltaUsage) {
-            usage = { ...usage, ...deltaUsage }
+            // Defensive merge: only update fields that are present and meaningful.
+            // Matches the pattern in claude.ts updateUsage() — prevents a future
+            // adapter change from silently zeroing cache fields via spread.
+            usage = updateOpenAIUsage(usage, deltaUsage)
           }
           if ((event as any).delta?.stop_reason != null) {
             stopReason = (event as any).delta.stop_reason


### PR DESCRIPTION
## Summary

将 OpenAI 路径中 `message_delta` 处理器的 `{ ...usage, ...deltaUsage }` 
spread 替换为 `updateOpenAIUsage()` 函数，与 `claude.ts` 的 `updateUsage()`
模式保持一致。

当前 OpenAI 适配器发送的 `message_delta` 包含完整字段，spread 不会丢失
数据。但若未来适配器在某事件中省略了 cache 字段（传 explicit 0），spread
会无声覆盖有效值。新函数仅在 delta 字段有意义值时更新，否则保留当前值。

## Context

跨 provider 缓存兼容性分析（见 PR #1225 的后续讨论）发现：
- Anthropic 路径使用 `updateUsage()` 做字段级保护合���
- OpenAI 路径使用裸 `{ ...usage, ...deltaUsage }` spread，缺少防御
- Codex/ChatGPT Responses API 路径同理（走同一个 `message_delta` 处理器）

## Test plan

- [x] tsc --noEmit 零错误
- [x] biome format 零差异
- [x] biome lint 零违规

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage tracking for OpenAI API calls to accurately preserve cache-related metrics and prevent unintended resets of cached token counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/claude-code-best/claude-code/pull/1232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->