### PR TITLE
fix: Gemini 适配器补全 usage 字段映射

### DIFF
--- a/packages/@ant/model-provider/src/providers/gemini/streamAdapter.ts
+++ b/packages/@ant/model-provider/src/providers/gemini/streamAdapter.ts
@@ -16,6 +16,7 @@ export async function* adaptGeminiStreamToAnthropic(
   let finishReason: string | undefined
   let inputTokens = 0
   let outputTokens = 0
+  let cachedReadTokens = 0
 
   for await (const chunk of stream) {
     const usage = chunk.usageMetadata
@@ -23,6 +24,7 @@ export async function* adaptGeminiStreamToAnthropic(
       inputTokens = usage.promptTokenCount ?? inputTokens
       outputTokens =
         (usage.candidatesTokenCount ?? 0) + (usage.thoughtsTokenCount ?? 0)
+      cachedReadTokens = usage.cachedContentTokenCount ?? cachedReadTokens
     }
 
     if (!started) {
@@ -41,7 +43,7 @@ export async function* adaptGeminiStreamToAnthropic(
             input_tokens: inputTokens,
             output_tokens: 0,
             cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 0,
+            cache_read_input_tokens: cachedReadTokens,
           },
         },
       } as unknown as BetaRawMessageStreamEvent
@@ -204,7 +206,10 @@ export async function* adaptGeminiStreamToAnthropic(
         stop_sequence: null,
       },
       usage: {
+        input_tokens: inputTokens,
         output_tokens: outputTokens,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: cachedReadTokens,
       },
     } as BetaRawMessageStreamEvent
 

--- a/packages/@ant/model-provider/src/providers/gemini/types.ts
+++ b/packages/@ant/model-provider/src/providers/gemini/types.ts
@@ -68,6 +68,7 @@ export type GeminiUsageMetadata = {
   candidatesTokenCount?: number
   thoughtsTokenCount?: number
   totalTokenCount?: number
+  cachedContentTokenCount?: number
 }
 
 export type GeminiCandidate = {


### PR DESCRIPTION
## Summary

Gemini API 的 `usageMetadata` 包含 `cachedContentTokenCount` 字段，
但此前未映射到 Anthropic 格式的 `cache_read_input_tokens`，导致
cache 相关字段始终为 0。

同时 `message_delta` 事件此前只携带 `output_tokens`，缺失
`input_tokens`、`cache_creation_input_tokens`、`cache_read_input_tokens`，
与 OpenAI/Anthropic 适配器不一致。下游代码（如 `cacheWarning.ts`、
`cacheStatsState.ts`、`StatusLine.tsx`）从 `message_delta` 读取
最终 token 计数时会获得不完整数据。

## Changes

1. 新增 `cachedContentTokenCount` → `cache_read_input_tokens` 映射
2. `message_start` 中的 `cache_read_input_tokens` 从固定 0 改为实际值
3. `message_delta` 从只发送 `output_tokens` 改为发送完整四个字段

## Gemini usageMetadata fields (per API docs)

| Gemini field | Anthropic mapping | Status |
|---|---|---|
| `promptTokenCount` | `input_tokens` | ✅ 已有 |
| `candidatesTokenCount` | `output_tokens` (part) | ✅ 已有 |
| `thoughtsTokenCount` | `output_tokens` (part) | ✅ 已有 |
| `cachedContentTokenCount` | `cache_read_input_tokens` | ✅ **新增** |
| (无等价) | `cache_creation_input_tokens` | 始终为 0 |

## Test plan

- [x] tsc --noEmit 零错误
- [x] biome format 零差异
- [x] biome lint 零违规

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token usage reporting now includes cached-content token reads in usage metrics.
  * Cached-read token counts are included in message start and message delta usage payloads, and final delta usage now reflects cached reads for more accurate reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/claude-code-best/claude-code/pull/1233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->