### PR TITLE
fix: isUsing3PServices 检查所有非 Anthropic provider

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1724,12 +1724,29 @@ export function getSubscriptionName(): string {
   }
 }
 
-/** Check if using third-party services (Bedrock or Vertex or Foundry) */
+/**
+ * Check if using third-party services (non-Anthropic providers).
+ *
+ * This function gates several behaviours that should only apply when the user
+ * is NOT calling the first-party Anthropic API directly:
+ *  - auth status display (authStatus handler)
+ *  - command visibility (login/logout shown for non-3P)
+ *  - command availability checks (meetsAvailabilityRequirement)
+ *
+ * KEEP IN SYNC with providers.ts — when a new CLAUDE_CODE_USE_* env var is
+ * added to getAPIProvider(), the corresponding check MUST be added here.
+ * Providers whose selection is controlled purely via settings.modelType
+ * (rather than env vars) are NOT covered by this function and may need
+ * separate handling in the call sites above.
+ */
 export function isUsing3PServices(): boolean {
   return !!(
     isEnvTruthy(process.env.CLAUDE_CODE_USE_BEDROCK) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_VERTEX) ||
-    isEnvTruthy(process.env.CLAUDE_CODE_USE_FOUNDRY)
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_FOUNDRY) ||
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI) ||
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_GROK)
   )
 }
 


### PR DESCRIPTION
## Summary

原 `isUsing3PServices()` 仅检查 Bedrock / Vertex / Foundry，遗漏了
OpenAI、Gemini、Grok 三个通过 `CLAUDE_CODE_USE_*` 环境变量切换的
第三方 provider。

这导致两个问题：
1. 命令可用性判定中 OpenAI/Gemini/Grok 用户被错误识别为 console 用户
   （`/fast`、`/install-github-app` 两个 Anthropic 专有命令误显示）
2. auth status 显示中这些用户被误报为"未登录"

## Changes

在函数中添加三个缺失的环境变量检查，并更新注释说明与 `providers.ts` 
的同步要求。

## Test plan

- [x] tsc --noEmit 零错误
- [x] biome format 零差异
- [x] biome lint 零违规

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting additional third-party AI provider environments (OpenAI, Gemini, Grok).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/claude-code-best/claude-code/pull/1235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->