### PR TITLE
fix: diff display edge cases for empty patches and hunks

### DIFF
--- a/src/components/FileEditToolDiff.tsx
+++ b/src/components/FileEditToolDiff.tsx
@@ -37,6 +37,15 @@ export function FileEditToolDiff(props: Props): React.ReactNode {
 function DiffBody({ promise, file_path }: { promise: Promise<DiffData>; file_path: string }): React.ReactNode {
   const { patch, firstLine, fileContent } = use(promise);
   const { columns } = useTerminalSize();
+
+  if (patch.length === 0) {
+    return (
+      <DiffFrame>
+        <Text dimColor>No changes to display</Text>
+      </DiffFrame>
+    );
+  }
+
   return (
     <DiffFrame>
       <StructuredDiffList

--- a/src/components/permissions/FileWritePermissionRequest/FileWriteToolDiff.tsx
+++ b/src/components/permissions/FileWritePermissionRequest/FileWriteToolDiff.tsx
@@ -46,7 +46,7 @@ export function FileWriteToolDiff({ file_path, content, fileExists, oldContent }
         borderRight={false}
         paddingX={paddingX}
       >
-        {hunks ? (
+        {hunks && hunks.length > 0 ? (
           intersperse(
             hunks.map(_ => (
               <StructuredDiff

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -153,6 +153,9 @@ export function getPatchForDisplay({
         convertLeadingTabsToSpaces(new_string),
       )
 
+      if (escapedOldString === '') {
+        return escapedNewString
+      }
       if (replace_all) {
         return p.replaceAll(escapedOldString, () => escapedNewString)
       } else {


### PR DESCRIPTION
- FileEditToolDiff: show "No changes to display" when patch is empty

- FileWriteToolDiff: guard against empty hunks array

- getPatchForDisplay: skip replace when old_string is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty diffs by displaying a clear "No changes to display" message instead of an empty list.
  * Enhanced diff display logic to gracefully render original code when no hunks are available.
  * Fixed edit application for insert-only operations to properly handle empty source content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/claude-code-best/claude-code/pull/1247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->