### PR TITLE
security: close telemetry leak in preconnectAnthropicApi startup path

### DIFF
--- a/src/utils/apiPreconnect.ts
+++ b/src/utils/apiPreconnect.ts
@@ -25,12 +25,17 @@
 
 import { getOauthConfig } from '../constants/oauth.js'
 import { isEnvTruthy } from './envUtils.js'
+import { isEssentialTrafficOnly } from './privacyLevel.js'
 
 let fired = false
 
 export function preconnectAnthropicApi(): void {
   if (fired) return
   fired = true
+
+  // Also skip when non-essential traffic is disabled via
+  // CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC / DISABLE_TELEMETRY / proxy env.
+  if (isEssentialTrafficOnly()) return
 
   // Skip if using a cloud provider — different endpoint + auth
   if (


### PR DESCRIPTION
🔒 Security Discovery: Un-gated outbound connection bypasses privacy controls

Summary
-------
preconnectAnthropicApi() unconditionally sends a TCP+TLS handshake to api.anthropic.com on every ccb startup — even when the user has explicitly disabled all non-essential traffic via CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 or DISABLE_TELEMETRY=1.

This is the LAST un-gated outbound connection in the entire startup path. Every other telemetry sink (Sentry, Langfuse, OpenTelemetry, GrowthBook, 1P Event Logger, Datadog, BigQuery, etc.) already respects the privacyLevel module's isEssentialTrafficOnly() gate. This one did not.

Impact
------
While the preconnect is a HEAD request with no payload, the connection itself leaks the client's IP address and session timing to Anthropic's infrastructure. For privacy-conscious users and enterprise deployments that have disabled telemetry, this constitutes an unexpected data leak.

Fix
---
Add isEssentialTrafficOnly() check at the function entry, consistent with every other privacy-gated code path in the codebase. The privacyLevel module is already imported by init.ts and 12+ other modules — no new dependencies.

Verification
------------
Reproduced and verified via strace on Linux (aarch64):

  # Before fix
  $ strace -f -e connect ccb -p <<< 'hello'
  connect(16, sin_addr=inet_addr("160.79.104.10"), sin_port=htons(443)) = 0
  # ↑ connector to api.anthropic.com despite CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1

  # After fix
  $ strace -f -e connect ccb -p <<< 'hello'
  # ↑ zero remote TCP connections — all traffic to localhost only

Changes: 1 file, +5 lines (import + gate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * App now respects the "essential traffic only" configuration by skipping unnecessary API preconnections when this mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->