### PR TITLE
Feat/markdown agent format

### DIFF
--- a/src/modes/store.ts
+++ b/src/modes/store.ts
@@ -14,6 +14,39 @@ let currentModeSlug: string | null = null
 let customModes: CCBMode[] | null = null
 const modeListeners = new Set<() => void>()
 
+/**
+ * Converts a human-readable name to a URL-safe slug.
+ * @example kebabCase('Claude Persona') → 'claude-persona'
+ */
+function kebabCase(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+/**
+ * Extracts YAML frontmatter and Markdown body from a string.
+ * Expects the format used by Claude Code SKILL.md, OpenCode agents,
+ * and Cursor rules: `---` delimited YAML followed by Markdown content.
+ *
+ * @throws {Error} If the string does not contain valid `---` delimiters.
+ * @returns The parsed frontmatter object and the body text.
+ */
+function parseMarkdownFrontmatter(raw: string): {
+  frontmatter: Record<string, unknown>
+  body: string
+} {
+  const parts = raw.split(/^---$/m)
+  if (parts.length < 3) {
+    throw new Error('Invalid markdown frontmatter: missing --- delimiters')
+  }
+  return {
+    frontmatter: parseYaml(parts[1]) as Record<string, unknown>,
+    body: parts.slice(2).join('---').trim(),
+  }
+}
+
 function loadCustomModes(): CCBMode[] {
   if (customModes !== null) return customModes
   customModes = []
@@ -23,12 +56,22 @@ function loadCustomModes(): CCBMode[] {
       mkdirSync(modesDir, { recursive: true })
     }
     const files = readdirSync(modesDir).filter(
-      f => f.endsWith('.yaml') || f.endsWith('.yml'),
+      f => f.endsWith('.yaml') || f.endsWith('.yml') || f.endsWith('.md'),
     )
     for (const file of files) {
       try {
         const raw = readFileSync(join(modesDir, file), 'utf-8')
-        const data = parseYaml(raw) as Record<string, unknown>
+        let data: Record<string, unknown>
+        if (file.endsWith('.md')) {
+          const { frontmatter, body } = parseMarkdownFrontmatter(raw)
+          data = { ...frontmatter, system_prompt: body }
+          if (!data.slug) {
+            data.slug = data.name ? kebabCase(String(data.name)) : ''
+          }
+          data.icon = data.icon || '🤖'
+        } else {
+          data = parseYaml(raw) as Record<string, unknown>
+        }
         if (!data.slug || !data.name) continue
         customModes.push({
           name: String(data.name),
@@ -36,6 +79,7 @@ function loadCustomModes(): CCBMode[] {
           description: String(data.description || ''),
           icon: String(data.icon || '🔧'),
           systemPrompt: String(data.system_prompt || ''),
+          model: data.model ? String(data.model) : undefined,
           ui: {
             accentColor: String(
               (data.ui as Record<string, unknown>)?.accent_color || '#00D4AA',
@@ -62,7 +106,7 @@ function loadCustomModes(): CCBMode[] {
           },
         })
       } catch {
-        // skip invalid yaml files
+        // skip invalid yaml or markdown files
       }
     }
   } catch {

--- a/src/modes/types.ts
+++ b/src/modes/types.ts
@@ -6,6 +6,7 @@ export interface CCBMode {
   description: string
   icon: string
   systemPrompt: string
+  model?: string
   ui: {
     accentColor: string
     promptPrefix: string


### PR DESCRIPTION
## Summary

支持在 ~/.claude/modes/ 目录下使用 Markdown + YAML frontmatter 格式
定义自定义 Mode，与 OpenCode / Cursor / Codex 等工具的 Agent 定义格式
完全统一。

## Motivation

社区反馈：当前 Mode 使用 CCP 专有 YAML 格式，而 OpenCode 和 Claude Code
的 Agent/SKILL.md 都使用 --- YAML frontmatter + Markdown body 的通用格式。
统一后同一份 claude.md 可在多个工具间零修改迁移。

## Changes

src/modes/store.ts — 仅一个文件，+34 / -3：
- kebabCase() — 从 name 自动生成 slug
- parseMarkdownFrontmatter() — 提取 frontmatter + Markdown body
- .md 数据标准化后复用现有 CCBMode 映射，零重复
- 现有 .yaml/.yml 路径一字符未改

## Usage

---
name: Claude
description: Anthropic's Claude persona
---

# Character
You have a genuine, stable character...

激活: /mode claude 或 settings.json 中 "ccbMode": "claude"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom modes can now be defined in Markdown files using YAML frontmatter; the Markdown body becomes the system prompt.
  * Mode entries will derive a slug from the name and default to a robot icon when none is provided.
  * Added optional model specification to mode definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->