### PR TITLE
fix: prevent null reference reading 'error' in MessagesBoundary

### DIFF
--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -753,6 +753,7 @@ export function normalizeMessages(messages: Message[]): NormalizedMessage[] {
   // and remains true for all subsequent messages in the normalization process.
   let isNewChain = false
   return messages.flatMap(message => {
+    if (!message) return [];
     switch (message.type) {
       case 'assistant': {
         const aMsg = message as AssistantMessage
@@ -776,7 +777,7 @@ export function normalizeMessages(messages: Message[]): NormalizedMessage[] {
             isVirtual: message.isVirtual,
             requestId: message.requestId,
             uuid,
-            error: message.error,
+            error: message?.error,
             isApiErrorMessage: message.isApiErrorMessage,
             advisorModel: message.advisorModel,
           } as NormalizedAssistantMessage
@@ -2376,6 +2377,7 @@ export function normalizeMessagesForAPI(
       },
     )
     .forEach(message => {
+      if (!message) return [];
       switch (message.type) {
         case 'system': {
           // local_command system messages need to be included as user messages

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -753,7 +753,7 @@ export function normalizeMessages(messages: Message[]): NormalizedMessage[] {
   // and remains true for all subsequent messages in the normalization process.
   let isNewChain = false
   return messages.flatMap(message => {
-    if (!message) return [];
+    if (!message) return []
     switch (message.type) {
       case 'assistant': {
         const aMsg = message as AssistantMessage
@@ -2377,7 +2377,7 @@ export function normalizeMessagesForAPI(
       },
     )
     .forEach(message => {
-      if (!message) return [];
+      if (!message) return []
       switch (message.type) {
         case 'system': {
           // local_command system messages need to be included as user messages

--- a/src/utils/messages/mappers.ts
+++ b/src/utils/messages/mappers.ts
@@ -29,6 +29,7 @@ export function toInternalMessages(
   messages: readonly DeepImmutable<SDKMessage>[],
 ): Message[] {
   return messages.flatMap(message => {
+    if (!message) return [];
     switch (message.type) {
       case 'assistant':
         return [
@@ -127,6 +128,7 @@ export function fromSDKCompactMetadata(
 
 export function toSDKMessages(messages: Message[]): SDKMessage[] {
   return messages.flatMap((message): SDKMessage[] => {
+    if (!message) return [];
     switch (message.type) {
       case 'assistant':
         return [
@@ -138,7 +140,7 @@ export function toSDKMessages(messages: Message[]): SDKMessage[] {
             session_id: getSessionId(),
             parent_tool_use_id: null,
             uuid: message.uuid,
-            error: message.error,
+            error: message?.error,
           },
         ]
       case 'user':

--- a/src/utils/messages/mappers.ts
+++ b/src/utils/messages/mappers.ts
@@ -29,7 +29,7 @@ export function toInternalMessages(
   messages: readonly DeepImmutable<SDKMessage>[],
 ): Message[] {
   return messages.flatMap(message => {
-    if (!message) return [];
+    if (!message) return []
     switch (message.type) {
       case 'assistant':
         return [
@@ -128,7 +128,7 @@ export function fromSDKCompactMetadata(
 
 export function toSDKMessages(messages: Message[]): SDKMessage[] {
   return messages.flatMap((message): SDKMessage[] => {
-    if (!message) return [];
+    if (!message) return []
     switch (message.type) {
       case 'assistant':
         return [


### PR DESCRIPTION
## Summary
- Fixes "Cannot read properties of null (reading 'error')" crash in `MessagesBoundary`
- The error boundary catches this during React render when `normalizeMessages` processes a message array containing null elements

## Root Cause
`normalizeMessages` is called inside `useMemo` at `src/components/Messages.tsx:410`, which executes synchronously during React render phase. When the messages array contains a null element (possible via JSONL deserialization, streaming race conditions, or compact/merge operations), `flatMap` passes it to the callback where `message.error` is accessed → `null.error` → `TypeError: Cannot read properties of null (reading 'error')`.

## Changes
| File | Change |
|------|--------|
| `src/utils/messages.ts:756` | Add `if (!message) return []` null guard in `normalizeMessages` flatMap |
| `src/utils/messages.ts:781` | `error: message.error` → `error: message?.error` |
| `src/utils/messages.ts:2380` | Add `if (!message) return []` null guard in `normalizeMessagesForAPI` forEach |
| `src/utils/messages/mappers.ts:32` | Add `if (!message) return []` null guard in `toInternalMessages` flatMap |
| `src/utils/messages/mappers.ts:131` | Add `if (!message) return []` null guard in `fromSDKCompactMetadata` flatMap |
| `src/utils/messages/mappers.ts:143` | `error: message.error` → `error: message?.error` |

## Verification
- All changes are purely defensive — no behavior change for non-null messages
- Optional chaining and null guards are standard TypeScript patterns
- Indentation verified at all 4 guard locations (4-space and 6-space matching surrounding code)

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message normalization and conversion to safely skip empty or missing message entries.
  * Prevented runtime errors by handling assistant message error details in a null-safe way.
  * Made message-processing more resilient when inputs contain unexpected `null`/`undefined` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->