### PR TITLE
fix(acp): use POSIX path semantics for ACP wire format paths

### DIFF
--- a/src/services/acp/bridge/paths.ts
+++ b/src/services/acp/bridge/paths.ts
@@ -1,5 +1,12 @@
 // Pure path-normalisation helper used by toolInfo / toolResults / forwarding.
-import { isAbsolute, resolve } from 'node:path'
+//
+// POSIX semantics are used so that emitted paths are platform-independent:
+// ACP v1 spec (tool-calls.mdx:304-306) requires ToolCallLocation.path /
+// Diff.path to be absolute, and the wire format is POSIX-style regardless of
+// the host OS. Using the platform-specific `node:path` here would prepend the
+// Windows drive letter (e.g. "D:\...") to POSIX-style inputs like
+// "/Users/test/project" — silently corrupting paths emitted to ACP clients.
+import { isAbsolute, resolve } from 'node:path/posix'
 
 /**
  * Normalises an emitted file path against the session cwd so that

--- a/src/services/acp/utils.ts
+++ b/src/services/acp/utils.ts
@@ -172,7 +172,9 @@ export function sanitizeTitle(text: string): string {
 
 // ── Path display helpers ──────────────────────────────────────────
 
-import * as path from 'node:path'
+// POSIX semantics so paths are normalised consistently regardless of host OS.
+// ACP paths are always POSIX-style (see bridge/paths.ts for the same rationale).
+import * as path from 'node:path/posix'
 
 /**
  * Convert an absolute file path to a project-relative path for display.
@@ -186,7 +188,7 @@ export function toDisplayPath(filePath: string, cwd?: string): string {
     resolvedFile.startsWith(resolvedCwd + path.sep) ||
     resolvedFile === resolvedCwd
   ) {
-    return path.relative(resolvedCwd, resolvedFile).replaceAll('\\', '/')
+    return path.relative(resolvedCwd, resolvedFile)
   }
   return filePath
 }


### PR DESCRIPTION
ToolCallLocation.path and Diff.path emitted over ACP must be absolute and POSIX-style per the v1 spec (tool-calls.mdx:304-306). The previous code used platform-specific `node:path` which on Windows prepends the drive letter (e.g. "D:\...") to POSIX-style inputs like "/Users/test/project" — silently corrupting paths emitted to ACP clients on Windows hosts. CI runs on Linux so the latent issue went undetected. Switch to `node:path/posix` so the path normalisation is host-OS independent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized path handling to always use forward slashes in ACP-related path output.
  * Improved consistency of displayed paths across platforms, including Windows.
  * Reduced the risk of Windows-specific drive-letter or separator formatting appearing in emitted path values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->