### PR TITLE
feat: /compact 保留上下文并新增流式 token 进度条

### DIFF
--- a/src/commands/compact/compact.ts
+++ b/src/commands/compact/compact.ts
@@ -23,6 +23,7 @@ import type { ToolUseContext } from '../../Tool.js'
 import type { LocalCommandCall } from '../../types/command.js'
 import type { Message } from '../../types/message.js'
 import { hasExactErrorMessage } from '../../utils/errors.js'
+import { formatTokens } from '../../utils/format.js'
 import { executePreCompactHooks } from '../../utils/hooks.js'
 import { logError } from '../../utils/log.js'
 import { getMessagesAfterCompactBoundary } from '../../utils/messages.js'
@@ -78,7 +79,10 @@ export const call: LocalCommandCall = async (args, context) => {
         return {
           type: 'compact',
           compactionResult: sessionMemoryResult,
-          displayText: buildDisplayText(context),
+          displayText: buildDisplayText(context, undefined, {
+            pre: sessionMemoryResult.preCompactTokenCount,
+            post: sessionMemoryResult.truePostCompactTokenCount,
+          }),
         }
       }
     }
@@ -121,7 +125,10 @@ export const call: LocalCommandCall = async (args, context) => {
     return {
       type: 'compact',
       compactionResult: result,
-      displayText: buildDisplayText(context, result.userDisplayMessage),
+      displayText: buildDisplayText(context, result.userDisplayMessage, {
+        pre: result.preCompactTokenCount,
+        post: result.truePostCompactTokenCount,
+      }),
     }
   } catch (error) {
     if (abortController.signal.aborted) {
@@ -218,7 +225,10 @@ async function compactViaReactive(
         ...outcome.result!,
         userDisplayMessage: combinedMessage,
       },
-      displayText: buildDisplayText(context, combinedMessage),
+      displayText: buildDisplayText(context, combinedMessage, {
+        pre: outcome.result!.preCompactTokenCount,
+        post: outcome.result!.truePostCompactTokenCount,
+      }),
     }
   } finally {
     context.setStreamMode?.('requesting')
@@ -231,6 +241,7 @@ async function compactViaReactive(
 function buildDisplayText(
   context: ToolUseContext,
   userDisplayMessage?: string,
+  tokenCounts?: { pre?: number; post?: number },
 ): string {
   const upgradeMessage = getUpgradeMessage('tip')
   const expandShortcut = getShortcutDisplay(
@@ -238,10 +249,15 @@ function buildDisplayText(
     'Global',
     'ctrl+o',
   )
+  const tokenLine =
+    tokenCounts?.pre !== undefined && tokenCounts.post !== undefined
+      ? `Context: ~${formatTokens(tokenCounts.pre)} \u2192 ~${formatTokens(tokenCounts.post)} tokens`
+      : undefined
   const dimmed = [
     ...(context.options.verbose
       ? []
       : [`(${expandShortcut} to see full summary)`]),
+    ...(tokenLine ? [tokenLine] : []),
     ...(userDisplayMessage ? [userDisplayMessage] : []),
     ...(upgradeMessage ? [upgradeMessage] : []),
   ]

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -32,7 +32,6 @@ import { collapseReadSearchGroups } from '../utils/collapseReadSearch.js';
 import { collapseTeammateShutdowns } from '../utils/collapseTeammateShutdowns.js';
 import { getGlobalConfig } from '../utils/config.js';
 import { isEnvTruthy } from '../utils/envUtils.js';
-import { isFullscreenEnvEnabled } from '../utils/fullscreen.js';
 import { applyGrouping } from '../utils/groupToolUses.js';
 import {
   buildMessageLookups,
@@ -41,7 +40,6 @@ import {
   updateMessageLookupsIncremental,
   createAssistantMessage,
   deriveUUID,
-  getMessagesAfterCompactBoundary,
   getToolUseID,
   getToolUseIDs,
   hasUnresolvedHooksFromLookup,
@@ -543,12 +541,13 @@ const MessagesImpl = ({
     // (this PR's core goal — full history in UI, filter only for the model).
     // Also avoids a UUID mismatch: normalizeMessages derives new UUIDs, so
     // projectSnippedView's check against original removedUuids would fail.
-    const compactAwareMessages =
-      verbose || isFullscreenEnvEnabled()
-        ? normalizedMessages
-        : getMessagesAfterCompactBoundary(normalizedMessages, {
-            includeSnipped: true,
-          });
+    // Keep the full pre-compact history visible in every view (not just
+    // verbose/transcript). The model context is filtered separately in
+    // query.ts via getMessagesAfterCompactBoundary, so retaining the messages
+    // here only affects display: after /compact the user still sees the prior
+    // conversation (with the compact_boundary marker inline as the signal),
+    // while tokens are still freed from the API request.
+    const compactAwareMessages = normalizedMessages;
 
     const messagesToShowNotTruncated = reorderMessagesInUI(
       compactAwareMessages.filter(

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -63,6 +63,8 @@ type Props = {
   overrideMessage?: string | null;
   spinnerSuffix?: string | null;
   verbose: boolean;
+  /** True while a compaction summary is streaming — shows a token progress bar. */
+  compactProgressActiveRef?: React.RefObject<boolean>;
   hasActiveTools?: boolean;
   /** Leader's turn has completed (no active query). Used to suppress stall-red spinner when only teammates are running. */
   leaderIsIdle?: boolean;
@@ -110,6 +112,7 @@ function SpinnerWithVerbInner({
   overrideMessage,
   spinnerSuffix,
   verbose,
+  compactProgressActiveRef,
   hasActiveTools = false,
   leaderIsIdle = false,
 }: Props): React.ReactNode {
@@ -352,6 +355,7 @@ function SpinnerWithVerbInner({
         spinnerSuffix={spinnerSuffix}
         verbose={verbose}
         columns={columns}
+        compactProgressActiveRef={compactProgressActiveRef}
         hasRunningTeammates={hasRunningTeammates}
         teammateTokens={teammateTokens}
         foregroundedTeammate={foregroundedTeammate}

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -1,7 +1,7 @@
 import figures from 'figures';
 import * as React from 'react';
 import { useMemo, useRef } from 'react';
-import { Box, Text, useAnimationFrame, stringWidth, Byline } from '@anthropic/ink';
+import { Box, Text, useAnimationFrame, stringWidth, Byline, ProgressBar } from '@anthropic/ink';
 import { toInkColor } from '../../utils/ink.js';
 import type { InProcessTeammateTaskState } from '../../tasks/InProcessTeammateTask/types.js';
 import { formatDuration, formatNumber } from '../../utils/format.js';
@@ -48,6 +48,8 @@ export type SpinnerAnimationRowProps = {
   spinnerSuffix?: string | null;
   verbose: boolean;
   columns: number;
+  /** True while a compaction summary is streaming — renders a token progress bar. */
+  compactProgressActiveRef?: React.RefObject<boolean>;
 
   // Teammate-derived (computed by parent from tasks)
   hasRunningTeammates: boolean;
@@ -86,6 +88,7 @@ export function SpinnerAnimationRow({
   spinnerSuffix,
   verbose,
   columns,
+  compactProgressActiveRef,
   hasRunningTeammates,
   teammateTokens,
   foregroundedTeammate,
@@ -283,7 +286,14 @@ export function SpinnerAnimationRow({
       )
     ) : null;
 
-  return (
+  // Compaction progress bar. Summary length is unknown up front, so map
+  // streamed tokens through an asymptotic curve (approaches but never reaches
+  // 100%) so it always reads as forward progress. Bar disappears on compact_end.
+  const isCompacting = compactProgressActiveRef?.current === true;
+  const compactRatio = isCompacting ? 1 - Math.exp(-leaderTokens / 1200) : 0;
+  const compactBarWidth = Math.max(10, Math.min(30, columns - 20));
+
+  const spinnerRow = (
     <Box ref={viewportRef} flexDirection="row" flexWrap="wrap" marginTop={1} width="100%">
       <SpinnerGlyph
         frame={frame}
@@ -302,6 +312,18 @@ export function SpinnerAnimationRow({
         stalledIntensity={overrideColor ? 0 : stalledIntensity}
       />
       {status}
+    </Box>
+  );
+
+  if (!isCompacting) return spinnerRow;
+
+  return (
+    <Box flexDirection="column" width="100%">
+      {spinnerRow}
+      <Box flexDirection="row">
+        <ProgressBar ratio={compactRatio} width={compactBarWidth} fillColor={messageColor} />
+        <Text dimColor> {Math.round(compactRatio * 100)}%</Text>
+      </Box>
     </Box>
   );
 }

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -1750,6 +1750,7 @@ export function REPL({
   // Ref instead of state to avoid triggering React re-renders on every
   // streaming text_delta. The spinner reads this via its animation timer.
   const responseLengthRef = useRef(0);
+  const compactProgressActiveRef = useRef(false);
   // API performance metrics ref for ant-only spinner display (TTFT/OTPS).
   // Accumulates metrics from all API requests in a turn for P50 aggregation.
   const apiMetricsRef = useRef<
@@ -3011,11 +3012,13 @@ export function REPL({
               break;
             case 'compact_start':
               setSpinnerMessage('Compacting conversation');
+              compactProgressActiveRef.current = true;
               break;
             case 'compact_end':
               setSpinnerMessage(null);
               setSpinnerColor(null);
               setSpinnerShimmerColor(null);
+              compactProgressActiveRef.current = false;
               break;
           }
         },
@@ -5953,6 +5956,7 @@ export function REPL({
                   spinnerTip={spinnerTip}
                   responseLengthRef={responseLengthRef}
                   apiMetricsRef={apiMetricsRef}
+                  compactProgressActiveRef={compactProgressActiveRef}
                   overrideMessage={spinnerMessage}
                   spinnerSuffix={stopHookSpinnerSuffix}
                   verbose={verbose}

--- a/src/services/compact/compact.ts
+++ b/src/services/compact/compact.ts
@@ -1230,7 +1230,13 @@ async function streamCompactSummary({
           // Pass the compact context's abortController so user Esc aborts the
           // fork — same signal the streaming fallback uses at
           // `signal: context.abortController.signal` below.
-          overrides: { abortController: context.abortController },
+          // Share setResponseLength so streamed summary tokens drive the
+          // compaction progress bar (the fork path is the default; without
+          // this the bar sits at 0% until compact_end).
+          overrides: {
+            abortController: context.abortController,
+            shareSetResponseLength: true,
+          },
         })
         const assistantMsg = getLastAssistantMessage(result.messages)
         const assistantText = assistantMsg

--- a/src/utils/forkedAgent.ts
+++ b/src/utils/forkedAgent.ts
@@ -587,6 +587,18 @@ export async function runForkedAgent({
         if (isMessageDeltaStreamEvent(message)) {
           const turnUsage = updateUsage({ ...EMPTY_USAGE }, message.event.usage)
           totalUsage = accumulateUsage(totalUsage, turnUsage)
+        } else {
+          // Feed streamed text length into the (optionally shared) response
+          // length callback so callers with shareSetResponseLength can drive
+          // token-based UI (e.g. the compaction progress bar). No-op by default.
+          const event = (message as StreamEventMessage).event
+          if (
+            event.type === 'content_block_delta' &&
+            event.delta.type === 'text_delta'
+          ) {
+            const textLength = event.delta.text.length
+            isolatedToolUseContext.setResponseLength(len => len + textLength)
+          }
         }
         continue
       }


### PR DESCRIPTION
- 默认视图保留 compact 前完整历史(不折叠不置灰),仅为显示层改动; 模型上下文仍在 query.ts 按 compact boundary 独立切片,token 照常释放
- compact 阶段新增基于流式 token 的进度条(渐近曲线 1-e^(-tokens/1200)), compact 结束后自动消失
- compact 结束打印压缩前后token变化量
<img width="1008" height="174" alt="dursion" src="https://github.com/user-attachments/assets/041d38aa-df65-48b5-be0f-e6bee41fa9f7" />
<img width="792" height="168" alt="result" src="https://github.com/user-attachments/assets/d477f63e-3c7d-44d1-987d-3308f902c86f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live progress bar showing compaction progress as a percentage.
  * Compaction results now display the context size before and after compaction.
  * Preserved pre-compaction conversation history in the visible message view.

* **Bug Fixes**
  * Improved progress tracking while compaction summaries are generated and streamed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->