### PR TITLE
Fix/claude cli to ccb

### DIFF
--- a/src/components/ultraplan/UltraplanChoiceDialog.tsx
+++ b/src/components/ultraplan/UltraplanChoiceDialog.tsx
@@ -139,7 +139,7 @@ export function UltraplanChoiceDialog({
             setMessages(prev => [
               ...prev,
               createSystemMessage(
-                `Previous session saved · resume with: claude --resume ${previousSessionId}`,
+                `Previous session saved · resume with: ccb --resume ${previousSessionId}`,
                 'suggestion',
               ),
             ]);

--- a/src/services/tips/tipRegistry.ts
+++ b/src/services/tips/tipRegistry.ts
@@ -375,7 +375,7 @@ const externalTips: Tip[] = [
   {
     id: 'continue',
     content: async () =>
-      'Run claude --continue or claude --resume to resume a conversation',
+      'Run ccb --continue or ccb --resume to resume a conversation',
     cooldownSessions: 10,
     isRelevant: async () => true,
   },

--- a/src/utils/crossProjectResume.ts
+++ b/src/utils/crossProjectResume.ts
@@ -41,7 +41,7 @@ export function checkCrossProjectResume(
   // Gate worktree detection to ants only for staged rollout
   if (process.env.USER_TYPE !== 'ant') {
     const sessionId = getSessionIdFromLog(log)
-    const command = `cd ${quote([log.projectPath])} && claude --resume ${sessionId}`
+    const command = `cd ${quote([log.projectPath])} && ccb --resume ${sessionId}`
     return {
       isCrossProject: true,
       isSameRepoWorktree: false,
@@ -65,7 +65,7 @@ export function checkCrossProjectResume(
 
   // Different repo - generate cd command
   const sessionId = getSessionIdFromLog(log)
-  const command = `cd ${quote([log.projectPath])} && claude --resume ${sessionId}`
+  const command = `cd ${quote([log.projectPath])} && ccb --resume ${sessionId}`
   return {
     isCrossProject: true,
     isSameRepoWorktree: false,

--- a/src/utils/gracefulShutdown.ts
+++ b/src/utils/gracefulShutdown.ts
@@ -169,9 +169,7 @@ function printResumeHint(): void {
 
       writeSync(
         1,
-        chalk.dim(
-          `\nResume this session with:\nccb --resume ${resumeArg}\n`,
-        ),
+        chalk.dim(`\nResume this session with:\nccb --resume ${resumeArg}\n`),
       )
       resumeHintPrinted = true
     } catch {

--- a/src/utils/gracefulShutdown.ts
+++ b/src/utils/gracefulShutdown.ts
@@ -170,7 +170,7 @@ function printResumeHint(): void {
       writeSync(
         1,
         chalk.dim(
-          `\nResume this session with:\nclaude --resume ${resumeArg}\n`,
+          `\nResume this session with:\nccb --resume ${resumeArg}\n`,
         ),
       )
       resumeHintPrinted = true


### PR DESCRIPTION
# CLI 退出后 resume 提示命令与启动命令不一致

## 问题描述

项目的 bin 命令名是 `ccb`（见 `package.json` 中 `"bin": { "ccb": "dist/cli-node.js" }`），但 CLI 退出后提示用户恢复会话时，显示的命令仍为 `claude --resume`，与实际启动命令 `ccb` 不一致，导致用户复制粘贴后无法执行。

## 复现步骤

1. 通过 `ccb` 启动 CLI 进行一次会话
2. 退出 CLI（Ctrl+C 或正常退出）
3. 终端底部显示：
   ```
   Resume this session with:
   claude --resume <session-id>
   ```
4. 复制执行 `claude --resume <session-id>` → 命令未找到

## 涉及位置

共 5 处用户可见的 `claude --resume` / `claude --continue` 提示：

| 文件 | 行号 | 场景 |
|------|------|------|
| `src/utils/gracefulShutdown.ts` | 173 | CLI 退出时的 resume 提示（主要问题） |
| `src/services/tips/tipRegistry.ts` | 378 | 随机 tip 提示 |
| `src/components/ultraplan/UltraplanChoiceDialog.tsx` | 142 | Ultraplan 会话保存提示 |
| `src/utils/crossProjectResume.ts` | 44 | 跨项目恢复命令（非 ant 用户） |
| `src/utils/crossProjectResume.ts` | 68 | 跨项目恢复命令（不同仓库） |

## 解决方案

将上述 5 处中的 `claude --resume` / `claude --continue` 全部替换为 `ccb --resume` / `ccb --continue`，与 `package.json` 中定义的 bin 名称保持一致。

## 影响

- 改动为纯字符串替换，无逻辑变更，无类型风险
- 所有用户可见的 resume 提示将与实际启动命令一致


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated resume instructions throughout the application to use `ccb --resume` instead of `claude --resume`.
  * Updated continuation tips to reference `ccb --continue` and `ccb --resume`.
  * Corrected resume commands for cross-project sessions.
  * Updated graceful shutdown resume hints to use `ccb --resume`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->