### PR TITLE
fix: 修复 Issue 模板选择器缺失

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug 报告
-description: 报告一个可复现的 bug
+about: 报告一个可复现的 bug
 title: "bug: "
 labels: ["bug"]
 assignees: []

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: 功能建议
-description: 提出新功能或改进建议
+about: 提出新功能或改进建议
 title: "feat: "
 labels: ["enhancement"]
 assignees: []


### PR DESCRIPTION
## 问题

GitHub Markdown Issue 模板要求使用 `about` 字段作为选择器描述。现有两个模板使用了不受支持的 `description`，导致模板无法正常显示在新建 Issue 的选择器中。

## 修改

- 将 Bug 报告模板的 `description` 更正为 `about`
- 将功能建议模板的 `description` 更正为 `about`

## 验证

- 校验两个模板的 frontmatter 均包含 GitHub 支持的字段
- `git diff --check` 通过

Fixes #1306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bug report and feature request templates to use the supported description field.
  * Existing template wording and content remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->