### PR TITLE
fix: 尊重 perf report 的自定义配置目录

### DIFF
--- a/src/commands/perf-issue/index.ts
+++ b/src/commands/perf-issue/index.ts
@@ -101,7 +101,7 @@ function sanitizeErrorMessage(msg: string): string {
 }
 
 function getPerfReportDir(): string {
-  return join(homedir(), '.claude', 'perf-reports')
+  return join(getClaudeConfigHomeDir(), 'perf-reports')
 }
 
 function getTranscriptPath(): string {


### PR DESCRIPTION
## 问题

`/perf-issue` 的会话转录路径已经通过 `getClaudeConfigHomeDir()` 尊重 `CLAUDE_CONFIG_DIR`，但报告输出目录仍硬编码为 `~/.claude/perf-reports`。这会破坏自定义配置目录的隔离，在 home 目录只读时也可能导致写入失败。

现有测试使用临时 `CLAUDE_CONFIG_DIR`；基线实现会将报告写到真实 home，因而有 5 个用例失败。

## 修改

将报告目录改为 `<Claude config dir>/perf-reports`，与转录、设置和其他配置数据使用相同的目录解析逻辑。未设置 `CLAUDE_CONFIG_DIR` 时仍保持原有的 `~/.claude/perf-reports` 行为。

## 验证

- `bun test src/commands/perf-issue/__tests__/perf-issue.test.ts`：16 pass / 0 fail
- `bun run typecheck` 通过
- `bunx biome ci .` 通过
- `bun run precheck`：5984 pass / 10 skip / 0 fail
- `bun run build:vite` 通过
- `git diff --check` 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the storage location for performance snapshot reports to use the configured Claude home directory, improving consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->