### PR TITLE
fix(windows): reject WSL bash.exe in findGitBashPath detection

### DIFF
--- a/src/utils/Shell.ts
+++ b/src/utils/Shell.ts
@@ -72,6 +72,42 @@ function isExecutable(shellPath: string): boolean {
  * Determines the best available shell to use.
  */
 export async function findSuitableShell(): Promise<string> {
+  // Windows-only one-shot warning: if WSL bash launcher is on PATH and no
+  // Git for Windows bash is detected, surface a warning so the user knows
+  // why hooks/BashTool will misbehave. The actual filtering lives in
+  // findExecutableWithDeps (windowsPaths.ts); this is purely user-facing.
+  if (
+    getPlatform() === 'windows' &&
+    !process.env.CLAUDE_CODE_GIT_BASH_PATH &&
+    !process.env.CLAUDE_CODE_GIT_BASH_PATH_WARNED
+  ) {
+    try {
+      const whereResult = execFileSync('where.exe', ['bash'], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        encoding: 'utf8',
+      })
+      const lines = whereResult
+        .split(/\r?\n/)
+        .map(l => l.trim().toLowerCase())
+        .filter(Boolean)
+      const hasWslBash = lines.some(l =>
+        /(?:system32|windowsapps)\\bash\.exe$/.test(l),
+      )
+      const hasGitBash = lines.some(l => /\\git\\.*bash\.exe$/.test(l))
+      if (hasWslBash && !hasGitBash) {
+        process.env.CLAUDE_CODE_GIT_BASH_PATH_WARNED = '1'
+        console.warn(
+          '[CCB] Detected WSL bash on PATH without Git for Windows. ' +
+            'Hooks and BashTool will not work correctly. ' +
+            'Install Git for Windows (https://git-scm.com/download/windows) ' +
+            'or set CLAUDE_CODE_GIT_BASH_PATH to your bash.exe.',
+        )
+      }
+    } catch {
+      // where.exe not available or failed — fall through silently
+    }
+  }
+
   // Check for explicit shell override first
   const shellOverride = process.env.CLAUDE_CODE_SHELL
   if (shellOverride) {

--- a/src/utils/__tests__/windowsPaths.test.ts
+++ b/src/utils/__tests__/windowsPaths.test.ts
@@ -322,4 +322,55 @@ describe('findGitBashPathOrNullWithDeps', () => {
     const result = findGitBashPathOrNullWithDeps(deps)
     expect(result).toBe(expectedBash)
   })
+
+  test('rejects WSL bash launcher (System32) and returns null when no Git Bash exists', () => {
+    // WSL feature on Windows ships C:\Windows\System32\bash.exe — a Linux
+    // distro launcher, NOT Git Bash. It must be rejected; if no Git for
+    // Windows exists, return null so findGitBashPath can exit(1) cleanly.
+    const wslBash = 'C:\\Windows\\System32\\bash.exe'
+    const deps: GitBashDiscoveryDeps = {
+      // Only the WSL launcher "exists" — Git Bash default locations do not,
+      // so step 4 fallback (searchDefaultBashLocations) also returns null.
+      checkExists: p => p === wslBash,
+      execCommand: cmd => (cmd.includes('where.exe bash') ? wslBash : ''),
+      cwdFn: () => 'C:\\safe\\cwd',
+      envOverride: '',
+    }
+    expect(findGitBashPathOrNullWithDeps(deps)).toBe(null)
+  })
+
+  test('rejects WSL App Execution Alias (WindowsApps) and returns null when no Git Bash exists', () => {
+    // %LOCALAPPDATA%\Microsoft\WindowsApps\bash.exe is the WSL App Execution
+    // Alias — a 0-byte reparse point that forwards to WSL. Same rejection.
+    const wslBash =
+      'C:\\Users\\foo\\AppData\\Local\\Microsoft\\WindowsApps\\bash.exe'
+    const deps: GitBashDiscoveryDeps = {
+      checkExists: p => p === wslBash,
+      execCommand: cmd => (cmd.includes('where.exe bash') ? wslBash : ''),
+      cwdFn: () => 'C:\\safe\\cwd',
+      envOverride: '',
+    }
+    expect(findGitBashPathOrNullWithDeps(deps)).toBe(null)
+  })
+
+  test('skips WSL bash and falls through to next where.exe hit (Git Bash later in PATH)', () => {
+    // Common case: user has WSL enabled AND Git for Windows installed.
+    // where.exe returns System32\bash.exe first (System32 is near front of
+    // PATH), then Git Bash later. Filter must skip the WSL entry and accept
+    // the legit one.
+    const wslBash = 'C:\\Windows\\System32\\bash.exe'
+    const legitBash = 'C:\\Program Files\\Git\\bin\\bash.exe'
+    const deps: GitBashDiscoveryDeps = {
+      checkExists: p => p === legitBash || p === wslBash,
+      execCommand: cmd => {
+        if (cmd.includes('where.exe bash')) {
+          return `${wslBash}\r\n${legitBash}`
+        }
+        return ''
+      },
+      cwdFn: () => 'C:\\safe\\cwd',
+      envOverride: '',
+    }
+    expect(findGitBashPathOrNullWithDeps(deps)).toBe(legitBash)
+  })
 })

--- a/src/utils/doctorDiagnostic.ts
+++ b/src/utils/doctorDiagnostic.ts
@@ -364,6 +364,33 @@ async function detectConfigurationIssues(
     // Parse errors are surfaced by the settings loader itself.
   }
 
+  // Windows-only: detect WSL bash launcher on PATH without Git for Windows.
+  // Independent of install method — affects every Windows user with WSL.
+  if (getPlatform() === 'windows') {
+    try {
+      const whereResult = await execFileNoThrow('where.exe', ['bash'])
+      if (whereResult.code === 0 && whereResult.stdout) {
+        const lines = whereResult.stdout
+          .split(/\r?\n/)
+          .map(l => l.trim().toLowerCase())
+          .filter(Boolean)
+        const hasWslBash = lines.some(l =>
+          /(?:system32|windowsapps)\\bash\.exe$/.test(l),
+        )
+        const hasGitBash = lines.some(l => /\\git\\.*bash\.exe$/.test(l))
+        if (hasWslBash && !hasGitBash) {
+          warnings.push({
+            issue:
+              'Windows PATH has WSL bash (C:\\Windows\\System32\\bash.exe) but no Git for Windows bash',
+            fix: 'Install Git for Windows (https://git-scm.com/download/windows). Without it, CCB cannot run hooks or BashTool correctly on Windows. If you cannot install it, set CLAUDE_CODE_GIT_BASH_PATH to a working bash.exe.',
+          })
+        }
+      }
+    } catch {
+      // where.exe not available or failed — skip this check
+    }
+  }
+
   const config = getGlobalConfig()
 
   // Skip most warnings for development mode

--- a/src/utils/windowsPaths.ts
+++ b/src/utils/windowsPaths.ts
@@ -157,6 +157,23 @@ function findExecutableWithDeps(
         continue
       }
 
+      // WSL-bash rejection: System32\bash.exe (WSL launcher) and
+      // WindowsApps\bash.exe (WSL App Execution Alias) must never be
+      // accepted as Git Bash. They look like bash but spawn wsl.exe,
+      // causing popup windows and Linux-semantics commands on Windows
+      // tasks. Only applies to bash.exe, not other executables looked
+      // up here (git, etc.). Continue to the next where.exe hit so a
+      // legit Git Bash later in PATH can still win.
+      if (
+        executable === 'bash' &&
+        /(?:system32|windowsapps)\\bash\.exe$/.test(normalizedPath)
+      ) {
+        logForDebugging(
+          `Skipping WSL bash launcher (not Git Bash): ${candidatePath}`,
+        )
+        continue
+      }
+
       // Return the first valid path that's not in the current directory
       return candidatePath
     }


### PR DESCRIPTION
## 问题

Windows 启用 WSL 时，`where.exe bash` 返回 `C:\Windows\System32\bash.exe`（WSL 启动器）和 `%LOCALAPPDATA%\Microsoft\WindowsApps\bash.exe`（WSL App Execution Alias），位置常在 Git for Windows 的 bash 之前。原 `findExecutableWithDeps` 直接返回首个非 cwd 结果，CCB 因此把 WSL 启动器误认为 Git Bash，污染 `process.env.SHELL` 与 `CLAUDE_CODE_GIT_BASH_PATH` 整个会话，所有 hook / BashTool 调用都会拉起 `wsl.exe` 弹窗。

## 修改

- **`src/utils/windowsPaths.ts`** — 在 `findExecutableWithDeps` 内、当 `executable='bash'` 时，过滤 System32 与 WindowsApps 的 bash.exe 候选。`continue` 到下一个 `where.exe` 命中，让 PATH 后续的合法 Git Bash 仍能胜出。下游消费者（`setShellIfWindows` env 传播、`hooks.ts` spawn 点、`Shell.ts` SHELL 分支）通过 env 缓存自动受益。
- **`src/utils/Shell.ts`** — `findSuitableShell` 启动入口：检测到 WSL bash 但无 Git for Windows 且未设 `CLAUDE_CODE_GIT_BASH_PATH` override 时，输出一次性 warning。
- **`src/utils/doctorDiagnostic.ts`** — 相同条件的 `claude doctor` 持久诊断项，方便用户随时复查。

## Test plan

- [x] 新增 3 个单元测试覆盖该过滤器（`src/utils/__tests__/windowsPaths.test.ts`）：
  - 拒绝 WSL System32 bash → `null`
  - 拒绝 WSL WindowsApps bash → `null`
  - 跳过 WSL bash，fall through 到下一个 `where.exe` 命中（Git Bash later in PATH）
- [x] `bun run precheck` 通过：typecheck 0 errors / biome 0 fixes / **5987 pass / 0 fail / 10 skip**
- [x] Windows 实机：启用 WSL + 仅装 Git for Windows 的机器上，确认 hook 和 BashTool 不再触发 `wsl.exe` 弹窗
- [x] Windows 实机：仅启用 WSL（无 Git for Windows）时，`claude doctor` 输出对应 warning 项

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows shell detection to avoid selecting WSL Bash when Git Bash is unavailable.
  * Continued searching for valid Git Bash installations when unsuitable Bash launchers are found.
  * Added clearer diagnostics and remediation guidance for missing Git Bash configurations.
  * Prevented shell-detection failures from interrupting normal operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->