### PR TITLE
fix: write .claude.json to ~/.claude/ instead of homedir root

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -22,7 +22,10 @@ export const getGlobalClaudeFile = memoize((): string => {
   }
 
   const filename = `.claude${fileSuffixForOauthConfig()}.json`
-  return join(process.env.CLAUDE_CONFIG_DIR || homedir(), filename)
+  return join(
+    process.env.CLAUDE_CONFIG_DIR || getClaudeConfigHomeDir(),
+    filename,
+  )
 })
 
 const hasInternetAccess = memoize(async (): Promise<boolean> => {


### PR DESCRIPTION
将 .claude.json 写入路径从 homedir() 根目录改为 getClaudeConfigHomeDir() 对应的 ~/.claude/ 目录。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration file discovery by respecting the configured Claude settings directory.
  * Preserved support for custom configuration directory overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->