### PR TITLE
fix: 避免 && 短路时误用未执行命令的退出码语义

### DIFF
--- a/packages/builtin-tools/src/tools/BashTool/__tests__/commandSemantics.test.ts
+++ b/packages/builtin-tools/src/tools/BashTool/__tests__/commandSemantics.test.ts
@@ -59,6 +59,34 @@ describe('interpretCommandResult', () => {
     expect(result.message).toBe('No matches found')
   })
 
+  test('does not use an unexecuted rg command for && short-circuit semantics', () => {
+    const result = interpretCommandResult(
+      'cd /definitely-missing && rg pattern .',
+      1,
+      '',
+      'cd: /definitely-missing: No such file or directory',
+    )
+    expect(result.isError).toBe(true)
+    expect(result.message).toBe('Command failed with exit code 1')
+  })
+
+  test('does not use an unexecuted diff command for && short-circuit semantics', () => {
+    const result = interpretCommandResult(
+      "node -e 'process.exit(1)' && diff a.txt b.txt",
+      1,
+      '',
+      '',
+    )
+    expect(result.isError).toBe(true)
+    expect(result.message).toBe('Command failed with exit code 1')
+  })
+
+  test('keeps fallback semantics for a command reached through ||', () => {
+    const result = interpretCommandResult('false || rg pattern .', 1, '', '')
+    expect(result.isError).toBe(false)
+    expect(result.message).toBe('No matches found')
+  })
+
   // ─── rg (ripgrep) semantics ──────────────────────────────────────
   test('rg exit 1 means no matches (not error)', () => {
     const result = interpretCommandResult('rg pattern', 1, '', '')

--- a/packages/builtin-tools/src/tools/BashTool/commandSemantics.ts
+++ b/packages/builtin-tools/src/tools/BashTool/commandSemantics.ts
@@ -5,7 +5,10 @@
  * For example, grep returns 1 when no matches are found, which is not an error condition.
  */
 
-import { splitCommand_DEPRECATED } from 'src/utils/bash/commands.js'
+import {
+  splitCommand_DEPRECATED,
+  splitCommandWithOperators,
+} from 'src/utils/bash/commands.js'
 
 export type CommandSemantic = (
   exitCode: number,
@@ -110,6 +113,17 @@ function extractBaseCommand(command: string): string {
  * May get it super wrong - don't depend on this for security
  */
 function heuristicallyExtractBaseCommand(command: string): string {
+  // With an && list, the syntactically last command may never have run.  For
+  // example, `cd /missing && rg needle .` exits 1 from `cd`, but applying rg's
+  // "1 = no matches" semantics would turn that real failure into success.
+  // The executor currently only exposes the aggregate exit code, so fall back
+  // to the conservative default whenever an AND-list makes the executed
+  // command ambiguous. Pipes remain safe: without pipefail their last command
+  // determines the aggregate status and is always executed.
+  if (splitCommandWithOperators(command).includes('&&')) {
+    return ''
+  }
+
   const segments = splitCommand_DEPRECATED(command)
 
   // Take the last command as that's what determines the exit code


### PR DESCRIPTION
## Summary

- 使用保留控制运算符的命令解析结果识别 `&&` list。
- 当聚合退出码无法确定来自哪个语法段时，回退到默认非零退出码语义。
- 保留简单 `rg`、管道和纯 `||` 的既有特殊语义。
- 增加前置失败 + `rg` / `diff` 短路回归及 `false || rg` 控制组。

这样可以避免 `test-command && rg ...` 中测试失败时，把根本未执行的 `rg` 当成“无匹配”。

## Test plan

- [x] `bun test packages/builtin-tools/src/tools/BashTool/__tests__/commandSemantics.test.ts`（14 pass）
- [x] `bun run typecheck`
- [x] Biome check（改动文件）
- [x] `git diff --check`

## 关联 issue

`Closes #1344`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of compound shell commands using `&&` and `||`.
  * Commands that are skipped due to short-circuiting no longer incorrectly affect the reported result.
  * Preserved accurate fallback behavior for commands reached through `||`.
  * Existing pipeline command handling remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->