### PR TITLE
fix: parallel/pipeline 不应吞掉工作流取消异常

### DIFF
--- a/packages/workflow-engine/src/__tests__/hooks.test.ts
+++ b/packages/workflow-engine/src/__tests__/hooks.test.ts
@@ -617,6 +617,17 @@ test('parallel single item throws → logger.warn records the failure reason', a
   expect(warns[0]).toMatch(/boom-x/)
 })
 
+test('parallel rethrows workflow cancellation instead of converting it to null', async () => {
+  const { hooks } = buildCtx()
+  await expect(
+    hooks.parallel([
+      async () => {
+        throw new WorkflowAbortedError()
+      },
+    ]),
+  ).rejects.toBeInstanceOf(WorkflowAbortedError)
+})
+
 test('pipeline chains stage by stage, stage throws → null', async () => {
   const { hooks } = buildCtx()
   const out = await hooks.pipeline(
@@ -643,6 +654,15 @@ test('pipeline stage throws → logger.warn records the failure reason', async (
   )
   expect(warns.length).toBe(1)
   expect(warns[0]).toMatch(/stage-boom/)
+})
+
+test('pipeline rethrows workflow cancellation instead of converting it to null', async () => {
+  const { hooks } = buildCtx()
+  await expect(
+    hooks.pipeline([1], async () => {
+      throw new WorkflowAbortedError()
+    }),
+  ).rejects.toBeInstanceOf(WorkflowAbortedError)
 })
 
 test('pipeline over 4096 throws', async () => {

--- a/packages/workflow-engine/src/__tests__/runWorkflow.test.ts
+++ b/packages/workflow-engine/src/__tests__/runWorkflow.test.ts
@@ -192,6 +192,41 @@ test('abort → killed', async () => {
   }
 })
 
+test('abort inside parallel and pipeline remains killed through run_done', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'wf-run-'))
+  try {
+    const cases = [
+      ['parallel', `return parallel([() => agent('x')])`],
+      ['pipeline', `return pipeline(['x'], (_prev, item) => agent(item))`],
+    ] as const
+
+    for (const [name, script] of cases) {
+      const { ports, events } = portsWithEvents(dir, new Map())
+      const ac = new AbortController()
+      ac.abort()
+      const result = await runWorkflow({
+        script,
+        runId: `run-abort-${name}`,
+        ports,
+        host: createHostHandle(null),
+        signal: ac.signal,
+        cwd: dir,
+        budgetTotal: null,
+      })
+
+      expect(result.status).toBe('killed')
+      expect(events.findLast(event => event.type === 'run_done')).toMatchObject(
+        {
+          type: 'run_done',
+          status: 'killed',
+        },
+      )
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
 test('workflow() nesting (one level) shares counts', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'wf-run-'))
   try {

--- a/packages/workflow-engine/src/engine/hooks.ts
+++ b/packages/workflow-engine/src/engine/hooks.ts
@@ -273,6 +273,10 @@ export function makeHooks(
         try {
           return await t()
         } catch (e) {
+          // Cancellation is control flow for the entire run, not an item-level
+          // failure. Swallowing it here makes runWorkflow persist a killed run
+          // as successfully completed with a null item.
+          if (e instanceof WorkflowAbortedError) throw e
           // The "null on error" contract is unchanged, but it should log — otherwise the workflow author cannot locate why an agent failed
           ctx.ports.logger.warn?.(
             `parallel thunk #${i} failed: ${(e as Error).message}`,
@@ -303,6 +307,9 @@ export function makeHooks(
           }
           return prev as R
         } catch (e) {
+          // Keep user cancellation observable by runWorkflow so it can emit
+          // and persist the terminal `killed` state.
+          if (e instanceof WorkflowAbortedError) throw e
           ctx.ports.logger.warn?.(
             `pipeline item #${index} failed: ${(e as Error).message}`,
           )


### PR DESCRIPTION
## Summary

- 在 `parallel()` 和 `pipeline()` 中重新抛出 `WorkflowAbortedError`。
- 普通 thunk/stage 异常继续按既有契约记录 warning 并返回 `null`。
- 增加 hooks 单元测试和 `runWorkflow` 端到端状态测试。

修复后，用户取消组合 workflow 时，result、`run_done` 事件和持久化终态都保持为 `killed`，不会错误显示 `completed: [null]`。

## Test plan

- [x] `bun test packages/workflow-engine/src/__tests__/hooks.test.ts packages/workflow-engine/src/__tests__/runWorkflow.test.ts`（61 pass）
- [x] `bun run typecheck`
- [x] Biome check（改动文件）
- [x] `git diff --check`

## 关联 issue

`Closes #1345`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow cancellation handling for parallel and pipeline executions.
  * Aborted workflows now correctly report a `killed` status and emit the final completion event.
  * Other execution errors continue to use the existing warning and fallback behavior.

* **Tests**
  * Added coverage for cancellation handling in parallel, pipeline, and end-to-end workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->