### PR TITLE
perf: 为 tool_result 建立惰性索引，避免 /artifacts 二次方扫描

### DIFF
--- a/src/commands/artifacts/__tests__/scanner.test.ts
+++ b/src/commands/artifacts/__tests__/scanner.test.ts
@@ -155,4 +155,44 @@ describe('extractArtifacts', () => {
 
     expect(result.map(r => r.basename)).toEqual(['b.html', 'a.html'])
   })
+
+  test('indexes multiple artifacts while preserving first-result-wins semantics', () => {
+    const messages: Message[] = [
+      assistantToolUse('tu1', { file_path: '/tmp/a.html' }),
+      assistantToolUse('tu2', { file_path: '/tmp/b.html' }),
+      userToolResult(
+        'tu1',
+        'https://x.test/first.html (id: first, expires: 2026-06-27T10:00:00.000Z)',
+      ),
+      userToolResult(
+        'tu1',
+        'https://x.test/duplicate.html (id: duplicate, expires: 2026-06-28T10:00:00.000Z)',
+      ),
+      userToolResult(
+        'tu2',
+        'https://x.test/second.html (id: second, expires: 2026-06-29T10:00:00.000Z)',
+      ),
+    ]
+
+    const result = extractArtifacts(messages)
+
+    expect(result.map(r => r.hash)).toEqual(['second', 'first'])
+  })
+
+  test('still pairs a tool_result that appears before its artifact tool_use', () => {
+    const messages: Message[] = [
+      userToolResult(
+        'tu1',
+        'https://x.test/a.html (id: a, expires: 2026-06-27T10:00:00.000Z)',
+      ),
+      userToolResult(
+        'tu2',
+        'https://x.test/b.html (id: b, expires: 2026-06-28T10:00:00.000Z)',
+      ),
+      assistantToolUse('tu1', { file_path: '/tmp/a.html' }),
+      assistantToolUse('tu2', { file_path: '/tmp/b.html' }),
+    ]
+
+    expect(extractArtifacts(messages).map(r => r.hash)).toEqual(['b', 'a'])
+  })
 })

--- a/src/commands/artifacts/scanner.ts
+++ b/src/commands/artifacts/scanner.ts
@@ -16,8 +16,15 @@ const URL_REGEX = /https?:\/\/[^\s)"',]+\.html\b/
 const ID_REGEX = /\bid:\s*([A-Za-z0-9_-]+)/
 const EXPIRES_REGEX = /\bexpires:\s*([0-9T:.Z+-]+)/
 
+type ArtifactToolResult = {
+  content: unknown
+  is_error?: boolean
+}
+
 export function extractArtifacts(messages: Message[]): ArtifactInfo[] {
   const results: ArtifactInfo[] = []
+  let artifactUseCount = 0
+  let indexedResults: Map<string, ArtifactToolResult> | null = null
 
   for (const message of messages) {
     if (message.type !== 'assistant') continue
@@ -35,7 +42,19 @@ export function extractArtifacts(messages: Message[]): ArtifactInfo[] {
       const input = b.input as { file_path?: string } | undefined
       const filePath = input?.file_path ?? '<unknown>'
 
-      const resultBlock = findToolResult(messages, toolUseId)
+      artifactUseCount++
+      if (artifactUseCount === 2) {
+        // One direct lookup is already linear and avoids allocating an index
+        // for the common single-artifact case. Starting with the second use,
+        // index tool results once instead of rescanning the transcript for
+        // every artifact (which becomes quadratic in artifact-heavy sessions).
+        indexedResults = indexToolResults(messages)
+      }
+
+      const resultBlock = indexedResults
+        ? (indexedResults.get(toolUseId) ?? null)
+        : findToolResult(messages, toolUseId)
+
       if (!resultBlock) continue
 
       const rawContent =
@@ -78,7 +97,7 @@ export function extractArtifacts(messages: Message[]): ArtifactInfo[] {
 function findToolResult(
   messages: Message[],
   toolUseId: string,
-): { content: unknown; is_error?: boolean } | null {
+): ArtifactToolResult | null {
   for (const message of messages) {
     if (message.type !== 'user') continue
     const content = message.message?.content
@@ -94,4 +113,33 @@ function findToolResult(
     }
   }
   return null
+}
+
+function indexToolResults(
+  messages: Message[],
+): Map<string, ArtifactToolResult> {
+  const results = new Map<string, ArtifactToolResult>()
+
+  for (const message of messages) {
+    if (message.type !== 'user') continue
+    const content = message.message?.content
+    if (!Array.isArray(content)) continue
+
+    for (const block of content) {
+      if (typeof block !== 'object' || block === null) continue
+      if (!('type' in block)) continue
+      const b = block as unknown as Record<string, unknown>
+      if (b.type !== 'tool_result') continue
+      const toolUseId = b.tool_use_id as string
+      if (results.has(toolUseId)) continue
+
+      // Match findToolResult's first-result-wins behavior for duplicate IDs.
+      results.set(toolUseId, {
+        content: b.content,
+        is_error: b.is_error as boolean | undefined,
+      })
+    }
+  }
+
+  return results
 }


### PR DESCRIPTION
## Summary

- 首个 artifact 保留原有直接查找路径。
- 从第 2 个 artifact 开始，一次扫描建立 first-result-wins 的 `tool_result` 索引。
- 后续 artifact 通过 `tool_use_id` 常数时间查找，避免对 transcript 反复全表扫描。
- 增加重复 result ID、多个 artifact 和 result-before-use 等价性测试。

## Benchmark

每场景 60 对预热，3 trial × 120 次随机平衡 AB/BA，共 360 样本/实现；所有输出严格等价。

| 场景 | median | p95 |
| --- | ---: | ---: |
| 1k / 25 artifacts | 0.20054 → 0.05370 ms（3.73×） | 0.20179 → 0.05491 ms（3.68×） |
| 2k / 200 | 2.70905 → 0.28186 ms（9.61×） | 2.71983 → 0.29307 ms（9.28×） |
| 10k / 500 | 31.96035 → 0.91182 ms（35.05×） | 32.04902 → 0.95202 ms（33.66×） |

低基数边界：1k / 1 artifact 的 median 为 0.02630 → 0.02901 ms（+2.7 μs），p95 为 0.04004 → 0.04104 ms；未宣称所有场景都加速。

## Test plan

- [x] `bun test src/commands/artifacts/__tests__/scanner.test.ts`（8 pass）
- [x] `bun run typecheck`
- [x] Biome check（改动文件）
- [x] `git diff --check`
- [x] duplicate / unmatched / array content / error / malformed fixture 严格等价

## 关联 issue

`Closes #1346`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved artifact detection when multiple artifacts are indexed.
  - Correctly pairs tool results that appear before their corresponding artifact actions.
  - Preserves the first matching result when duplicate results are present.

- **Performance**
  - Improved efficiency when processing conversations containing repeated artifact actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->