### PR TITLE
fix: 修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,11 @@ TUI (REPL) 模式需要真实终端，无法直接通过 VS Code launch 启动�
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=claude-code-best%2Fclaude-code&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#claude-code-best/claude-code&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=claude-code-best/claude-code&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=claude-code-best/claude-code&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=claude-code-best/claude-code&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=claude-code-best/claude-code&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=claude-code-best/claude-code&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=claude-code-best/claude-code&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -198,11 +198,11 @@ The TUI (REPL) mode requires a real terminal and cannot be launched directly via
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=claude-code-best%2Fclaude-code&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#claude-code-best/claude-code&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=claude-code-best%2Fclaude-code&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=claude-code-best%2Fclaude-code&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=claude-code-best%2Fclaude-code&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=claude-code-best/claude-code&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=claude-code-best/claude-code&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=claude-code-best/claude-code&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
当前 README 中的 Star History 图表已无法正常展示，原因是 GitHub stargazer API 的限制导致原服务失效。该项目需要恢复可用的 Star History 图表，因此将图表链接切换至无需 API token 的替代服务，并已在多个大型开源项目（如 JavaGuide、dify）中得到验证。

改动内容：
- 更新 README.md 与 README_EN.md 中的 Star History 图表链接及图片地址

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History widget to use the new `star-history.dera.page` service.
  * Improved embedded chart URLs with SVG output and standard repository paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->