### PR TITLE
fix: /login 模型配置页面，输入模型名称时，输入w 直接进入workspace api key 页面无法完成模型配置

### DIFF
--- a/src/commands/login/login.tsx
+++ b/src/commands/login/login.tsx
@@ -77,6 +77,7 @@ export function Login(props: {
 }): React.ReactNode {
   const mainLoopModel = useMainLoopModel();
   const [showWorkspaceKeyInput, setShowWorkspaceKeyInput] = React.useState(false);
+  // Whether the login method selection is active
   const [loginMethodSelectionActive, setLoginMethodSelectionActive] = React.useState(true);
   // 'idle' | 'confirm-remove' | 'removing' | { error: string }
   const [removeState, setRemoveState] = React.useState<
@@ -121,6 +122,7 @@ export function Login(props: {
         }
         return;
       }
+      // Only allow workspace key input if login method selection is active
       if ((input === 'w' || input === 'W') && loginMethodSelectionActive) {
         setShowWorkspaceKeyInput(true);
         return;

--- a/src/commands/login/login.tsx
+++ b/src/commands/login/login.tsx
@@ -77,6 +77,7 @@ export function Login(props: {
 }): React.ReactNode {
   const mainLoopModel = useMainLoopModel();
   const [showWorkspaceKeyInput, setShowWorkspaceKeyInput] = React.useState(false);
+  const [loginMethodSelectionActive, setLoginMethodSelectionActive] = React.useState(true);
   // 'idle' | 'confirm-remove' | 'removing' | { error: string }
   const [removeState, setRemoveState] = React.useState<
     { phase: 'idle' } | { phase: 'confirm-remove' } | { phase: 'removing' } | { phase: 'error'; message: string }
@@ -120,7 +121,7 @@ export function Login(props: {
         }
         return;
       }
-      if (input === 'w' || input === 'W') {
+      if ((input === 'w' || input === 'W') && loginMethodSelectionActive) {
         setShowWorkspaceKeyInput(true);
         return;
       }
@@ -171,21 +172,24 @@ export function Login(props: {
           </Box>
         ) : (
           <>
-            <Box flexDirection="column" marginBottom={1}>
-              {!workspaceKeySet ? (
-                <Text dimColor>Press W to enter workspace API key (saves to settings, no restart needed)</Text>
-              ) : workspaceKeyFromSettings ? (
-                <Text dimColor>Press W to replace workspace API key · Press D to remove it</Text>
-              ) : (
-                <Text dimColor>
-                  Workspace API key from ANTHROPIC_API_KEY env. Press W to override with a settings-saved key.
-                </Text>
-              )}
-              {removeState.phase === 'error' && <Text color="error">{removeState.message}</Text>}
-            </Box>
+            {loginMethodSelectionActive && (
+              <Box flexDirection="column" marginBottom={1}>
+                {!workspaceKeySet ? (
+                  <Text dimColor>Press W to enter workspace API key (saves to settings, no restart needed)</Text>
+                ) : workspaceKeyFromSettings ? (
+                  <Text dimColor>Press W to replace workspace API key · Press D to remove it</Text>
+                ) : (
+                  <Text dimColor>
+                    Workspace API key from ANTHROPIC_API_KEY env. Press W to override with a settings-saved key.
+                  </Text>
+                )}
+                {removeState.phase === 'error' && <Text color="error">{removeState.message}</Text>}
+              </Box>
+            )}
             <ConsoleOAuthFlow
               onDone={() => props.onDone(true, mainLoopModel)}
               startingMessage={props.startingMessage}
+              onLoginMethodSelectionActiveChange={setLoginMethodSelectionActive}
             />
           </>
         )}

--- a/src/components/ConsoleOAuthFlow.tsx
+++ b/src/components/ConsoleOAuthFlow.tsx
@@ -31,6 +31,7 @@ type Props = {
   startingMessage?: string;
   mode?: 'login' | 'setup-token';
   forceLoginMethod?: 'claudeai' | 'console';
+  onLoginMethodSelectionActiveChange?: (active: boolean) => void;
 };
 
 type OAuthStatus =
@@ -89,6 +90,7 @@ export function ConsoleOAuthFlow({
   startingMessage,
   mode = 'login',
   forceLoginMethod: forceLoginMethodProp,
+  onLoginMethodSelectionActiveChange,
 }: Props): React.ReactNode {
   const settings = getSettings_DEPRECATED() || {};
   const forceLoginMethod = forceLoginMethodProp ?? settings.forceLoginMethod;
@@ -143,6 +145,10 @@ export function ConsoleOAuthFlow({
       return () => clearTimeout(timer);
     }
   }, [oauthStatus]);
+
+  useEffect(() => {
+    onLoginMethodSelectionActiveChange?.(oauthStatus.state === 'idle');
+  }, [oauthStatus.state, onLoginMethodSelectionActiveChange]);
 
   // Handle Enter to continue on success state
   useKeybinding(

--- a/src/components/ConsoleOAuthFlow.tsx
+++ b/src/components/ConsoleOAuthFlow.tsx
@@ -146,6 +146,7 @@ export function ConsoleOAuthFlow({
     }
   }, [oauthStatus]);
 
+  // Update login method selection active state
   useEffect(() => {
     onLoginMethodSelectionActiveChange?.(oauthStatus.state === 'idle');
   }, [oauthStatus.state, onLoginMethodSelectionActiveChange]);


### PR DESCRIPTION
<img width="1338" height="750" alt="image" src="https://github.com/user-attachments/assets/93f103a8-0351-47b9-bf11-2f526db8fe93" /> 
在这个界面输入 w，会直接进入
<img width="1138" height="512" alt="image" src="https://github.com/user-attachments/assets/c551ae83-0e69-4fa2-a630-cc181c3fb745" /> 
无法完成配置，如qwen等模型无法进行配置



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login-method selection behavior in the console.
  * Workspace-key entry and related guidance now appear only while selecting a login method.
  * Login-method state updates correctly as OAuth sign-in progresses, keeping available options and guidance synchronized with the current sign-in screen.
  * Prevented workspace-key prompts and error messaging from appearing during other stages of OAuth authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->