### PR TITLE
fix: handle Windows IME backspace (0x08) in mixed text tokens

### DIFF
--- a/packages/@ant/ink/src/core/__tests__/vietnamese-ime.test.ts
+++ b/packages/@ant/ink/src/core/__tests__/vietnamese-ime.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test'
+import { parseMultipleKeypresses, INITIAL_STATE } from '../parse-keypress.js'
+
+// Simulates Windows Vietnamese IME: backspace-and-replace composition.
+// Telex: typing 'việt' = v-i-e-e-j-t produces bytes (UTF-8):
+//   v = 0x76
+//   i = 0x69
+//   e = 0x65
+//   e = 0x08 + 0xC3 0xAA  (BS + 'ê')
+//   j = 0x08 + 0xE1 0xBB 0x87  (BS + 'ệ')
+//   t = 0x74
+//
+// On Windows raw stdin (utf8 encoding) these can arrive as one or two chunks.
+// The bug: BS+char in same chunk is NOT recognized as backspace → old char
+// stays + new char appended → "viêệt" doubled.
+
+function feed(state: ReturnType<typeof INITIAL_STATE extends infer S ? () => S : never>, chunk: string) {
+  return parseMultipleKeypresses(state, chunk)
+}
+
+describe('Vietnamese IME input (Windows BS 0x08)', () => {
+  test('single chunk: "v" + "\\b" + "ê" + "\\b" + "ệ" + "t" produces correct sequence', () => {
+    const chunks = [
+      'v',
+      'i',
+      'e',
+      '\bê', // BS + 'ê'
+      '\bệ', // BS + 'ệ'
+      't',
+    ]
+    let state = INITIAL_STATE
+    const all: string[] = []
+    for (const c of chunks) {
+      const [keys, ns] = feed(state, c)
+      state = ns
+      for (const k of keys) {
+        if (k.kind === 'key') {
+          if (k.name === 'backspace') all.push('BS')
+          else all.push((k as any).input || (k as any).sequence || '')
+        }
+      }
+    }
+    // Telex: 'việt' = v-i-e(hold)-j-t. IME emits: v,i,e then \b+ê then \b+ệ then t.
+    // So keystroke-derived expected: v, i, e, BS, ê, BS, ệ, t.
+    expect(all).toEqual(['v', 'i', 'e', 'BS', 'ê', 'BS', 'ệ', 't'])
+  })
+
+  test('whole "việt" in one chunk is split correctly', () => {
+    // Worst case: whole word arrives in one read
+    const chunk = 'vie' + '\bê' + '\bệ' + 't' // 8 chars: v i e BS ê BS ệ t
+    let state = INITIAL_STATE
+    const [keys, _] = parseMultipleKeypresses(state, chunk)
+    const names = keys.map(k => k.kind === 'key' ? (k.name || '') : '').join(',')
+    const hasBackspace = keys.filter(k => k.kind === 'key' && k.name === 'backspace').length
+    // Should contain at least 2 backspace events (one per composition)
+    expect(hasBackspace).toBeGreaterThanOrEqual(2)
+  })
+
+  test('regression: pure "\\b" still recognized as backspace', () => {
+    const [keys] = parseMultipleKeypresses(INITIAL_STATE, '\b')
+    expect(keys).toHaveLength(1)
+    expect((keys[0] as any).name).toBe('backspace')
+  })
+
+  test('regression: pure "\\x7f" still recognized as backspace', () => {
+    const [keys] = parseMultipleKeypresses(INITIAL_STATE, '\x7f')
+    expect(keys).toHaveLength(1)
+    expect((keys[0] as any).name).toBe('backspace')
+  })
+})

--- a/packages/@ant/ink/src/core/parse-keypress.ts
+++ b/packages/@ant/ink/src/core/parse-keypress.ts
@@ -8,6 +8,20 @@ import { Buffer } from 'buffer'
 import { PASTE_END, PASTE_START } from './termio/csi.js'
 import { createTokenizer, type Tokenizer } from './termio/tokenize.js'
 
+// Windows Vietnamese IME (OpenKey, UniKey, EVKey, built-in Telex) composes
+// accented chars by emitting a backspace (0x08) followed by the replacement
+// UTF-8 char in the SAME stdin read. macOS/Linux IMEs use 0x7F (DEL) and the
+// existing parseKeypress handles that as a lone key, but when 0x08/0x7F is
+// mixed with printable text in one token, the existing matchers fall through
+// to `name=''` and the BS char leaks into the input stream — component sees
+// literal "\bê" as text and appends it, producing doubled chars (e.g.
+// "việt" → "viêệt"). Split mixed tokens on BS/DEL so each backspace is
+// emitted as a key event before the replacement text.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: 0x08/0x7F are terminal IME backspace chars
+const IME_BS_RE = /[\x08\x7f]/g
+// biome-ignore lint/suspicious/noControlCharactersInRegex: 0x08/0x7F are terminal IME backspace chars
+const IME_BS_TEST_RE = /[\x08\x7f]/
+
 // biome-ignore lint/suspicious/noControlCharactersInRegex: terminal escape sequence parsing
 const META_KEY_CODE_RE = /^(?:\x1b)([a-zA-Z0-9])$/
 
@@ -258,8 +272,41 @@ export function parseMultipleKeypresses(
     } else if (token.type === 'text') {
       if (inPaste) {
         pasteBuffer += token.value
+      } else if (IME_BS_TEST_RE.test(token.value)) {
+        // Split text containing backspace/DEL chars (Windows IME composition
+        // sends "\b<accented-char>" in one read). Emit each BS as its own
+        // key, and parse each printable run as a separate text keypress so
+        // input-event.ts sees a real backspace event and deletes the prior
+        // char instead of appending "\b<char>" as literal text.
+        const segments = token.value.split(IME_BS_RE)
+        const backspaces = (token.value.match(IME_BS_RE) ?? []).length
+        let i = 0
+        // segments has one more entry than backspaces; interleave:
+        // segment[0], BS, segment[1], BS, ..., segment[n]
+        for (let s = 0; s < segments.length; s++) {
+          const seg = segments[s]!
+          if (seg.length > 0) {
+            keys.push(parseKeypress(seg))
+          }
+          if (s < backspaces) {
+            keys.push({
+              kind: 'key',
+              name: 'backspace',
+              fn: false,
+              ctrl: false,
+              meta: false,
+              shift: false,
+              option: false,
+              super: false,
+              sequence: token.value.charCodeAt(i) === 0x08 ? '\b' : '\x7f',
+              raw: undefined,
+              isPasted: false,
+            })
+          }
+          i += seg.length + 1
+        }
       } else if (
-        /^\[<\d+;\d+;\d+[Mm]$/.test(token.value) ||
+        /^\[<(\d+);(\d+);(\d+)[Mm]$/.test(token.value) ||
         /^\[M[\x60-\x7f][\x20-\uffff]{2}$/.test(token.value)
       ) {
         // Orphaned SGR/X10 mouse tail (fullscreen only — mouse tracking is off


### PR DESCRIPTION
## Summary

Windows Vietnamese IME (OpenKey, UniKey, EVKey, built-in Telex) composes accented characters by emitting a backspace (0x08) followed by the replacement UTF-8 char in the SAME stdin read. When the parser receives a text token containing both BS and printable chars, it previously fell through to name='' and the BS char leaked into the input stream, causing doubled characters (e.g. 'việt' → 'viêệt').

This patch splits mixed text tokens on 0x08/0x7F, emitting each backspace as its own key event before the replacement text.

## Test Plan

- [x] Added test cases in 
- [x] All 4 new tests pass (multi-chunk, whole-word, regression pure \b, regression pure \x7f)
- [x] All 21 existing tests in @ant/ink pass
- [x] TypeScript typecheck passes (0 errors)
- [x] Biome lint rules pass

## Root Cause

In , when a text token contains both backspace (0x08) and printable characters in the same chunk (typical on Windows where IME sends  as one read), the existing matchers only recognized a lone  or  as backspace. Mixed tokens fell through to the default case with , causing the component to see literal  as text instead of a backspace event + text event.

## Fix

Before calling  on text tokens, check for presence of 0x08/0x7F. If found, split the token into segments and interleave explicit backspace key events.

## Related

Fixes anthropics/claude-code#33891 (same root cause in upstream)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vietnamese IME input handling on Windows.
  * Backspace characters received alongside typed text are now correctly interpreted as backspace keypresses.
  * Prevented control characters from appearing as literal text during IME composition.
  * Preserved recognition of standard backspace inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->